### PR TITLE
Fixed SOCKS listener temporary error check.

### DIFF
--- a/psiphon/socksProxy.go
+++ b/psiphon/socksProxy.go
@@ -21,9 +21,10 @@ package psiphon
 
 import (
 	"fmt"
-	socks "github.com/Psiphon-Inc/goptlib"
 	"net"
 	"sync"
+
+	socks "github.com/Psiphon-Inc/goptlib"
 )
 
 // SocksProxy is a SOCKS server that accepts local host connections
@@ -103,13 +104,13 @@ loop:
 		}
 		if err != nil {
 			Notice(NOTICE_ALERT, "SOCKS proxy accept error: %s", err)
-			if e, ok := err.(net.Error); ok && !e.Temporary() {
-				proxy.tunneler.SignalFailure()
-				// Fatal error, stop the proxy
-				break loop
+			if e, ok := err.(net.Error); ok && e.Temporary() {
+				// Temporary error, keep running
+				continue
 			}
-			// Temporary error, keep running
-			continue
+			// Fatal error, stop the proxy
+			proxy.tunneler.SignalFailure()
+			break loop
 		}
 		go func() {
 			err := proxy.socksConnectionHandler(socksConnection)


### PR DESCRIPTION
If the error is not of type net.Error, it should *not* be treated as a temporary error.