### PR TITLE
Fix: upstream HTTP proxy bugs

### DIFF
--- a/psiphon/TCPConn_windows.go
+++ b/psiphon/TCPConn_windows.go
@@ -73,11 +73,11 @@ func interruptibleTCPDial(addr string, config *DialConfig) (conn *TCPConn, err e
 
 		netConn, err := net.DialTimeout("tcp", dialAddr, config.ConnectTimeout)
 
-		if config.UpstreamHttpProxyAddress != "" {
-			err := HttpProxyConnect(netConn, addr)
-			if err != nil {
-				netConn = nil
-			}
+		if err == nil && config.UpstreamHttpProxyAddress != "" {
+			err = HttpProxyConnect(netConn, addr)
+		}
+		if err != nil {
+			netConn = nil
 		}
 
 		results <- &interruptibleDialResult{netConn, err}

--- a/psiphon/httpProxy.go
+++ b/psiphon/httpProxy.go
@@ -44,7 +44,7 @@ func NewHttpProxy(config *Config, tunneler Tunneler) (proxy *HttpProxy, err erro
 	listener, err := net.Listen(
 		"tcp", fmt.Sprintf("127.0.0.1:%d", config.LocalHttpProxyPort))
 	if err != nil {
-		if IsNetworkBindError(err) {
+		if IsAddressInUseError(err) {
 			NoticeHttpProxyPortInUse(config.LocalSocksProxyPort)
 		}
 		return nil, ContextError(err)

--- a/psiphon/socksProxy.go
+++ b/psiphon/socksProxy.go
@@ -46,7 +46,7 @@ func NewSocksProxy(config *Config, tunneler Tunneler) (proxy *SocksProxy, err er
 	listener, err := socks.ListenSocks(
 		"tcp", fmt.Sprintf("127.0.0.1:%d", config.LocalSocksProxyPort))
 	if err != nil {
-		if IsNetworkBindError(err) {
+		if IsAddressInUseError(err) {
 			NoticeSocksProxyPortInUse(config.LocalSocksProxyPort)
 		}
 		return nil, ContextError(err)

--- a/psiphon/utils.go
+++ b/psiphon/utils.go
@@ -26,8 +26,11 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"net"
+	"os"
 	"runtime"
 	"strings"
+	"syscall"
 	"time"
 )
 


### PR DESCRIPTION
* Broken error handling in Windows TCPConn related to
  HTTP proxy case.

* Testing revealed that response parsing in HttpProxyConnect
  was too strict. Now using Go's http.ReadResponse.