### PR TITLE
Add wait-for-network-connectivity functionality; misc. fix-ups

### DIFF
--- a/AndroidApp/app/src/main/java/ca/psiphon/psibot/Utils.java
+++ b/AndroidApp/app/src/main/java/ca/psiphon/psibot/Utils.java
@@ -100,6 +100,13 @@ public class Utils {
         return outputStream.toByteArray();
     }
 
+    public static boolean hasNetworkConnectivity(Context context) {
+        ConnectivityManager connectivityManager =
+                (ConnectivityManager)context.getSystemService(Context.CONNECTIVITY_SERVICE);
+        NetworkInfo networkInfo = connectivityManager.getActiveNetworkInfo();
+        return networkInfo != null && networkInfo.isConnected();
+    }
+
     public static String getNetworkTypeName(Context context) {
         ConnectivityManager connectivityManager =
                 (ConnectivityManager)context.getSystemService(Context.CONNECTIVITY_SERVICE);

--- a/AndroidLibrary/psi/psi.go
+++ b/AndroidLibrary/psi/psi.go
@@ -34,10 +34,8 @@ import (
 
 type PsiphonProvider interface {
 	Notice(noticeJSON string)
-
-	// TODO: return 'error'; at the moment gobind doesn't
-	// work with interface function return values.
-	BindToDevice(fileDescriptor int)
+	HasNetworkConnectivity() int
+	BindToDevice(fileDescriptor int) error
 }
 
 var controller *psiphon.Controller
@@ -54,6 +52,7 @@ func Start(configJson, embeddedServerEntryList string, provider PsiphonProvider)
 	if err != nil {
 		return fmt.Errorf("error loading configuration file: %s", err)
 	}
+	config.CheckNetworkConnectivityProvider = provider
 	config.BindToDeviceProvider = provider
 
 	err = psiphon.InitDataStore(config)

--- a/psiphon/LookupIP.go
+++ b/psiphon/LookupIP.go
@@ -23,6 +23,7 @@ package psiphon
 
 import (
 	"errors"
+	"fmt"
 	dns "github.com/Psiphon-Inc/dns"
 	"net"
 	"os"
@@ -62,8 +63,10 @@ func bindLookupIP(host string, config *DialConfig) (addrs []net.IP, err error) {
 	}
 	defer syscall.Close(socketFd)
 
-	// TODO: check BindToDevice result
-	config.BindToDeviceProvider.BindToDevice(socketFd)
+	err = config.BindToDeviceProvider.BindToDevice(socketFd)
+	if err != nil {
+		return nil, ContextError(fmt.Errorf("BindToDevice failed: %s", err))
+	}
 
 	// config.BindToDeviceDnsServer must be an IP address
 	ipAddr = net.ParseIP(config.BindToDeviceDnsServer)

--- a/psiphon/TCPConn_unix.go
+++ b/psiphon/TCPConn_unix.go
@@ -23,6 +23,7 @@ package psiphon
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"os"
 	"strconv"
@@ -61,8 +62,10 @@ func interruptibleTCPDial(addr string, config *DialConfig) (conn *TCPConn, err e
 	}()
 
 	if config.BindToDeviceProvider != nil {
-		// TODO: check BindToDevice result
-		config.BindToDeviceProvider.BindToDevice(socketFd)
+		err = config.BindToDeviceProvider.BindToDevice(socketFd)
+		if err != nil {
+			return nil, ContextError(fmt.Errorf("BindToDevice failed: %s", err))
+		}
 	}
 
 	// When using an upstream HTTP proxy, first connect to the proxy,

--- a/psiphon/config.go
+++ b/psiphon/config.go
@@ -29,7 +29,7 @@ import (
 // TODO: allow all params to be configured
 
 const (
-	VERSION                                      = "0.0.6"
+	VERSION                                      = "0.0.7"
 	DATA_STORE_FILENAME                          = "psiphon.db"
 	CONNECTION_WORKER_POOL_SIZE                  = 10
 	TUNNEL_POOL_SIZE                             = 1
@@ -80,6 +80,7 @@ type Config struct {
 	TunnelPoolSize                     int
 	PortForwardFailureThreshold        int
 	UpstreamHttpProxyAddress           string
+	CheckNetworkConnectivityProvider   NetworkConnectivityChecker
 	BindToDeviceProvider               DeviceBinder
 	BindToDeviceDnsServer              string
 	TargetServerEntry                  string
@@ -149,8 +150,12 @@ func LoadConfig(configJson []byte) (*Config, error) {
 		config.PortForwardFailureThreshold = PORT_FORWARD_FAILURE_THRESHOLD
 	}
 
+	if config.CheckNetworkConnectivityProvider != nil {
+		return nil, ContextError(errors.New("CheckNetworkConnectivityProvider interface must be set at runtime"))
+	}
+
 	if config.BindToDeviceProvider != nil {
-		return nil, ContextError(errors.New("interface must be set at runtime"))
+		return nil, ContextError(errors.New("BindToDeviceProvider interface must be set at runtime"))
 	}
 
 	return &config, nil

--- a/psiphon/controller.go
+++ b/psiphon/controller.go
@@ -165,6 +165,12 @@ func (controller *Controller) remoteServerListFetcher() {
 
 loop:
 	for {
+		if !WaitForNetworkConnectivity(
+			controller.config.CheckNetworkConnectivityProvider,
+			controller.shutdownBroadcast) {
+			break
+		}
+
 		err := FetchRemoteServerList(
 			controller.config, controller.fetchRemotePendingConns)
 
@@ -596,6 +602,12 @@ loop:
 		// There may already be a tunnel to this candidate. If so, skip it.
 		if controller.isActiveTunnelServerEntry(serverEntry) {
 			continue
+		}
+
+		if !WaitForNetworkConnectivity(
+			controller.config.CheckNetworkConnectivityProvider,
+			controller.stopEstablishingBroadcast) {
+			break loop
 		}
 
 		tunnel, err := EstablishTunnel(


### PR DESCRIPTION
* core may be configured with a callback that the core uses to
check for network connectivity before attempting to establish
network connections. The purpose is to save CPU/battery on
mobile devices, especially.

* AndroidLibrary/AndroidApp support for network connectivity

* Add and check 'error' return value for BindToDevice

* Minor clean up to AndroidApp notice handling