### PR TITLE
Re-enable support for the meekFrontingDomain server entry field

### DIFF
--- a/psiphon/dataStore.go
+++ b/psiphon/dataStore.go
@@ -434,6 +434,17 @@ func (iterator *ServerEntryIterator) Next() (serverEntry *ServerEntry, err error
 	if err != nil {
 		return nil, ContextError(err)
 	}
+
+	// Backwards compatibility: old server entries have a single meekFrontingDomain
+	// and not a meekFrontingAddresses array. By copying this one meekFrontingDomain
+	// into meekFrontingAddresses, this client effectively uses that single value
+	// as legacy clients do.
+
+	if len(serverEntry.MeekFrontingAddresses) == 0 && serverEntry.MeekFrontingDomain != "" {
+		serverEntry.MeekFrontingAddresses =
+			append(serverEntry.MeekFrontingAddresses, serverEntry.MeekFrontingDomain)
+	}
+
 	return serverEntry, nil
 }
 

--- a/psiphon/serverEntry.go
+++ b/psiphon/serverEntry.go
@@ -50,7 +50,8 @@ type ServerEntry struct {
 	MeekCookieEncryptionPublicKey string   `json:"meekCookieEncryptionPublicKey"`
 	MeekObfuscatedKey             string   `json:"meekObfuscatedKey"`
 	MeekFrontingHost              string   `json:"meekFrontingHost"`
-	MeekFrontingAddresses         []string `json:"MeekFrontingAddresses"`
+	MeekFrontingDomain            string   `json:"meekFrontingDomain"`
+	MeekFrontingAddresses         []string `json:"meekFrontingAddresses"`
 }
 
 // DecodeServerEntry extracts server entries from the encoding
@@ -70,6 +71,7 @@ func DecodeServerEntry(encodedServerEntry string) (serverEntry *ServerEntry, err
 	if err != nil {
 		return nil, ContextError(err)
 	}
+
 	return serverEntry, nil
 }
 


### PR DESCRIPTION
* This is to support testing with legacy server entries