### PR TITLE
Tweaks to Notices

### DIFF
--- a/AndroidLibrary/psi/psi.go
+++ b/AndroidLibrary/psi/psi.go
@@ -57,15 +57,17 @@ func Start(configJson, embeddedServerEntryList string, provider PsiphonProvider)
 	config.DeviceBinder = provider
 	config.DnsServerGetter = provider
 
-	err = psiphon.InitDataStore(config)
-	if err != nil {
-		return fmt.Errorf("error initializing datastore: %s", err)
-	}
-
 	psiphon.SetNoticeOutput(psiphon.NewNoticeReceiver(
 		func(notice []byte) {
 			provider.Notice(string(notice))
 		}))
+
+	// TODO: should following errors be Notices?
+
+	err = psiphon.InitDataStore(config)
+	if err != nil {
+		return fmt.Errorf("error initializing datastore: %s", err)
+	}
 
 	serverEntries, err := psiphon.DecodeAndValidateServerEntryList(embeddedServerEntryList)
 	if err != nil {

--- a/psiphon/TCPConn_unix.go
+++ b/psiphon/TCPConn_unix.go
@@ -73,6 +73,14 @@ func interruptibleTCPDial(addr string, config *DialConfig) (conn *TCPConn, err e
 	dialAddr := addr
 	if config.UpstreamHttpProxyAddress != "" {
 		dialAddr = config.UpstreamHttpProxyAddress
+
+		// Report connection errors in a notice, as user may have input
+		// invalid proxy address or credential
+		defer func() {
+			if err != nil {
+				NoticeUpstreamProxyError(err)
+			}
+		}()
 	}
 
 	// Get the remote IP and port, resolving a domain name if necessary
@@ -169,7 +177,7 @@ func interruptibleTCPDial(addr string, config *DialConfig) (conn *TCPConn, err e
 	// Going through upstream HTTP proxy
 	if config.UpstreamHttpProxyAddress != "" {
 		// This call can be interrupted by closing the pending conn
-		err := HttpProxyConnect(conn, addr)
+		err = HttpProxyConnect(conn, addr)
 		if err != nil {
 			return nil, ContextError(err)
 		}

--- a/psiphon/TCPConn_windows.go
+++ b/psiphon/TCPConn_windows.go
@@ -75,6 +75,9 @@ func interruptibleTCPDial(addr string, config *DialConfig) (conn *TCPConn, err e
 
 		if err == nil && config.UpstreamHttpProxyAddress != "" {
 			err = HttpProxyConnect(netConn, addr)
+			if err != nil {
+				NoticeUpstreamProxyError(err)
+			}
 		}
 		if err != nil {
 			netConn = nil

--- a/psiphon/config.go
+++ b/psiphon/config.go
@@ -29,7 +29,7 @@ import (
 // TODO: allow all params to be configured
 
 const (
-	VERSION                                      = "0.0.8"
+	VERSION                                      = "0.0.9"
 	DATA_STORE_FILENAME                          = "psiphon.db"
 	CONNECTION_WORKER_POOL_SIZE                  = 10
 	TUNNEL_POOL_SIZE                             = 1

--- a/psiphon/dataStore.go
+++ b/psiphon/dataStore.go
@@ -186,7 +186,10 @@ func StoreServerEntry(serverEntry *ServerEntry, replaceIfExists bool) error {
 			return ContextError(err)
 		}
 		if serverEntryExists && !replaceIfExists {
-			NoticeInfo("ignored update for server %s", serverEntry.IpAddress)
+			// Disabling this notice, for now, as it generates too much noise
+			// in diagnostics with clients that always submit embedded servers
+			// to the core on each run.
+			// NoticeInfo("ignored update for server %s", serverEntry.IpAddress)
 			return nil
 		}
 		_, err = transaction.Exec(`

--- a/psiphon/notice.go
+++ b/psiphon/notice.go
@@ -174,6 +174,12 @@ func NoticeSplitTunnelRegion(region string) {
 	outputNotice("SplitTunnelRegion", true, "region", region)
 }
 
+// NoticeUpstreamProxyError reports an error when connecting to an upstream proxy. The
+// user may have input, for example, an incorrect address or incorrect credentials.
+func NoticeUpstreamProxyError(err error) {
+	outputNotice("UpstreamProxyError", true, "errorMessage", fmt.Sprintf("%s", err))
+}
+
 type noticeObject struct {
 	NoticeType string          `json:"noticeType"`
 	Data       json.RawMessage `json:"data"`


### PR DESCRIPTION
* Disable "ignored server" notice due to noise in diagnostics
* Report critical ConsoleClient errors as notices (e.g., datastore init errors)
* Add special notice for upstream proxy error messages that may need to
  be relayed to users