### PR TITLE
Fix: HTTP proxy should not follow redirects

### DIFF
--- a/psiphon/httpProxy.go
+++ b/psiphon/httpProxy.go
@@ -91,7 +91,7 @@ func NewHttpProxy(
 		return DialTCP(addr, untunneledDialConfig)
 	}
 
-	// TODO: could HTTP proxy share a tunneled transort with URL proxy?
+	// TODO: could HTTP proxy share a tunneled transport with URL proxy?
 	// For now, keeping them distinct just to be conservative.
 	httpProxyTunneledRelay := &http.Transport{
 		Dial:                  tunneledDialer,


### PR DESCRIPTION
* URL proxy uses http.Client in order to handle
  cookies and redirects.
* HTTP proxy now reverted to simply use http.Transport,
  as using http.Client in this case was causing
  browsing issues (a standard proxy shouldn't follow
  redirects).