### PR TITLE
Fix upstreamproxy integration bugs

### DIFF
--- a/psiphon/net.go
+++ b/psiphon/net.go
@@ -34,6 +34,13 @@ const DNS_PORT = 53
 // of a Psiphon dialer (TCPDial, MeekDial, etc.)
 type DialConfig struct {
 
+	// ClosedSignal is triggered when an underlying TCPConn network
+	// connection is closed. This is used in operateTunnel to detect
+	// an unexpected disconnect. Channel should be have buffer to
+	// receive at least on signal. Sender in TCPConn.Close() does not
+	// block.
+	ClosedSignal chan struct{}
+
 	// UpstreamProxyUrl specifies a proxy to connect through.
 	// E.g., "http://proxyhost:8080"
 	//       "socks5://user:password@proxyhost:1080"

--- a/psiphon/upstreamproxy/upstreamproxy.go
+++ b/psiphon/upstreamproxy/upstreamproxy.go
@@ -33,8 +33,8 @@ type Error struct {
 }
 
 func proxyError(err error) error {
-	//Avoid multiple upstream.Error wrapping
-	if _, ok := err.(Error); ok {
+	// Avoid multiple upstream.Error wrapping
+	if _, ok := err.(*Error); ok {
 		return err
 	}
 	return &Error{error: fmt.Errorf("upstreamproxy error: %s", err)}


### PR DESCRIPTION
* Type assertions for upstreamproxy.Error were invalid
* Direct calls to DialTCP missed the upstreamproxy integration
  * Refactored NewTCPDialer/DialTCP to ensure both use upstreamproxy
  * Now DialTCP returns a net.Conn instead of a psiphon.TCPConn, since
    that's what we get from upstreamproxy's dialer
  * Reworked setting of CloseSignal since DialTCP callers no longer
    see psiphon.TCPConn instances