### PR TITLE
Fix: always send a status request

### DIFF
--- a/psiphon/transferstats/collector.go
+++ b/psiphon/transferstats/collector.go
@@ -150,12 +150,14 @@ func GetBytesTransferredForServer(serverID string) (sent, received int64) {
 }
 
 // GetForServer returns the json-able stats package for the given server.
-// If there are no stats, nil will be returned.
 func GetForServer(serverID string) (payload *serverStats) {
 	allStats.statsMutex.Lock()
 	defer allStats.statsMutex.Unlock()
 
 	payload = allStats.serverIDtoStats[serverID]
+	if payload == nil {
+		payload = newServerStats()
+	}
 	delete(allStats.serverIDtoStats, serverID)
 	return
 }

--- a/psiphon/tunnel.go
+++ b/psiphon/tunnel.go
@@ -717,11 +717,9 @@ func sendStats(tunnel *Tunnel) {
 	}
 
 	payload := transferstats.GetForServer(tunnel.serverEntry.IpAddress)
-	if payload != nil {
-		err := tunnel.session.DoStatusRequest(payload)
-		if err != nil {
-			NoticeAlert("DoStatusRequest failed for %s: %s", tunnel.serverEntry.IpAddress, err)
-			transferstats.PutBack(tunnel.serverEntry.IpAddress, payload)
-		}
+	err := tunnel.session.DoStatusRequest(payload)
+	if err != nil {
+		NoticeAlert("DoStatusRequest failed for %s: %s", tunnel.serverEntry.IpAddress, err)
+		transferstats.PutBack(tunnel.serverEntry.IpAddress, payload)
 	}
 }


### PR DESCRIPTION
* Previously, was not sending when tunnel was idle and no bytes transferred
* Problem: backend session duration logic depends on periodic status requests
* Now, when idle, will send a status request with 0 bytes transferred