### PR TITLE
Don't only migrate chosen region/protocol entries

### DIFF
--- a/ConsoleClient/README.md
+++ b/ConsoleClient/README.md
@@ -17,9 +17,10 @@ Note that you may need to use `sudo docker` below, depending on your OS.
     --rm \
     -v $(pwd):/go/src/github.com/Psiphon-Labs/psiphon-tunnel-core \
     psiclient \
-    /bin/bash -c 'cd /go/src/github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient && ./make.bash' \
+    /bin/bash -c 'cd /go/src/github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient && ./make.bash all' \
   ; cd -
   ```
+This command can also be modified by replacing `all` with `windows`, `linux`, or `osx` as the first parameter to `make.bash` (as in `...&& ./make.bash windows`) to only build binaries for the operating system of choice
 
 When that command completes, the compiled binaries will be located in the `bin` directory (`./bin`, and everything under it will likely be owned by root, so be sure to `chown` to an appropriate user) under the current directory. The structure will be:
   ```

--- a/ConsoleClient/make.bash
+++ b/ConsoleClient/make.bash
@@ -26,38 +26,77 @@ echo " Build repo: ${BUILDREPO}"
 echo " Build revision: ${BUILDREV}"
 echo ""
 
-echo "Getting project dependencies (via go get)"
-GOOS=linux go get -d -v ./...
-GOOS=windows go get -d -v ./...
-GOOS=darwin go get -d -v ./...
-
 if [ ! -d bin ]; then
   mkdir bin
 fi
 
-echo "Building windows-i686..."
-CC=/usr/bin/i686-w64-mingw32-gcc gox -verbose -ldflags "$LDFLAGS" -osarch windows/386 -output bin/windows/${EXE_BASENAME}-i686
-# We are finding that UPXing the full Windows Psiphon client produces better results if psiphon-tunnel-core.exe is not already UPX'd.
-echo "..No UPX for this build"
+build_for_windows () {
+  echo "...Getting project dependencies (via go get) for Windows"
+  GOOS=windows go get -d -v ./...
 
-echo "Building windows-x86_64..."
-CC=/usr/bin/x86_64-w64-mingw32-gcc gox -verbose -ldflags "$LDFLAGS" -osarch windows/amd64 -output bin/windows/${EXE_BASENAME}-x86_64
-# We are finding that UPXing the full Windows Psiphon client produces better results if psiphon-tunnel-core.exe is not already UPX'd.
-echo "..No UPX for this build"
+  echo "...Building windows-i686"
+  CC=/usr/bin/i686-w64-mingw32-gcc gox -verbose -ldflags "$LDFLAGS" -osarch windows/386 -output bin/windows/${EXE_BASENAME}-i686
+  # We are finding that UPXing the full Windows Psiphon client produces better results if psiphon-tunnel-core.exe is not already UPX'd.
+  echo "....No UPX for this build"
 
-echo "Building linux-i686..."
-CFLAGS=-m32 gox -verbose -ldflags "$LDFLAGS" -osarch linux/386 -output bin/linux/${EXE_BASENAME}-i686
-echo "..UPX packaging output"
-goupx --best bin/linux/${EXE_BASENAME}-i686
+  echo "...Building windows-x86_64"
+  CC=/usr/bin/x86_64-w64-mingw32-gcc gox -verbose -ldflags "$LDFLAGS" -osarch windows/amd64 -output bin/windows/${EXE_BASENAME}-x86_64
+  # We are finding that UPXing the full Windows Psiphon client produces better results if psiphon-tunnel-core.exe is not already UPX'd.
+  echo "....No UPX for this build"
+}
 
-echo "Building linux-x86_64..."
-gox -verbose -ldflags "$LDFLAGS" -osarch linux/amd64 -output bin/linux/${EXE_BASENAME}-x86_64
-echo "..UPX packaging output"
-goupx --best bin/linux/${EXE_BASENAME}-x86_64
+build_for_linux () {
+  echo "Getting project dependencies (via go get) for Linux"
+  GOOS=linux go get -d -v ./...
 
-echo "Building darwin-x86_64..."
-CGO_ENABLED=0 gox -verbose -ldflags "$LDFLAGS" -osarch darwin/amd64 -output bin/darwin/${EXE_BASENAME}-x86_64
-# Darwin binaries don't seem to be UPXable when built this way
-echo "..No UPX for this build"
+  echo "...Building linux-i686"
+  CFLAGS=-m32 gox -verbose -ldflags "$LDFLAGS" -osarch linux/386 -output bin/linux/${EXE_BASENAME}-i686
+  echo "....UPX packaging output"
+  goupx --best bin/linux/${EXE_BASENAME}-i686
+
+  echo "...Building linux-x86_64"
+  gox -verbose -ldflags "$LDFLAGS" -osarch linux/amd64 -output bin/linux/${EXE_BASENAME}-x86_64
+  echo "....UPX packaging output"
+  goupx --best bin/linux/${EXE_BASENAME}-x86_64
+}
+
+build_for_osx () {
+  echo "Getting project dependencies (via go get) for OSX"
+  GOOS=darwin go get -d -v ./...
+
+  echo "Building darwin-x86_64..."
+  CGO_ENABLED=0 gox -verbose -ldflags "$LDFLAGS" -osarch darwin/amd64 -output bin/darwin/${EXE_BASENAME}-x86_64
+  # Darwin binaries don't seem to be UPXable when built this way
+  echo "..No UPX for this build"
+}
+
+TARGET=$1
+case $TARGET in
+  windows)
+    echo "..Building for Windows"
+    build_for_windows
+    ;;
+  linux)
+    echo "..Building for Linux"
+    build_for_linux
+    ;;
+  osx)
+    echo "..Building for OSX"
+    build_for_osx
+    ;;
+  all)
+    echo "..Building all"
+    build_for_windows
+    build_for_linux
+    build_for_osx
+    ;;
+  *)
+    echo "..No selection made, building all"
+    build_for_windows
+    build_for_linux
+    build_for_osx
+    ;;
+
+esac
 
 echo "Done"


### PR DESCRIPTION
Also made `make.bash` able to build tunnel core binaries for individual platforms if desired