### PR TITLE
indistinguishable TLS via OpenSSL static linking for Windows binaries…

### DIFF
--- a/ConsoleClient/Dockerfile
+++ b/ConsoleClient/Dockerfile
@@ -4,11 +4,11 @@
 
 FROM ubuntu:15.04
 
-ENV GOVERSION=go1.5
+ENV GOVERSION=go1.5.3
 
 # Install system-level dependencies.
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get -y install build-essential curl git mercurial upx gcc-mingw-w64-i686 gcc-mingw-w64-x86-64 gcc-multilib
+RUN apt-get update && apt-get -y install build-essential curl git mercurial upx gcc-mingw-w64-i686 gcc-mingw-w64-x86-64 mingw-w64 gcc-multilib pkg-config
 
 # Install Go.
 ENV GOROOT=/usr/local/go GOPATH=/go
@@ -21,6 +21,15 @@ RUN curl -L https://storage.googleapis.com/golang/$GOVERSION.linux-amd64.tar.gz 
 
 ENV CGO_ENABLED=1
 
+# Get go dependencies
 RUN go get github.com/mitchellh/gox && go get github.com/pwaller/goupx
+
+# Build static OpenSSL libray
+ENV OPENSSL_VERSION=1.0.1p
+ENV PKG_CONFIG_PATH=/tmp/openssl/openssl-$OPENSSL_VERSION
+
+RUN curl -L https://github.com/Psiphon-Labs/psiphon-tunnel-core/raw/master/openssl/openssl-$OPENSSL_VERSION.tar.gz -o /tmp/openssl.tar.gz && \
+      mkdir -p /tmp/openssl && tar -C /tmp/openssl -xzf /tmp/openssl.tar.gz && rm /tmp/openssl.tar.gz
+RUN cd $PKG_CONFIG_PATH && ./Configure --cross-compile-prefix=i686-w64-mingw32- mingw no-shared no-ssl2 no-ssl3 no-comp no-hw no-md2 no-md4 no-rc2 no-rc5 no-krb5 no-ripemd160 no-idea no-gost no-camellia no-seed no-3des no-heartbeats && make depend && make
 
 WORKDIR $GOPATH/src

--- a/ConsoleClient/README.md
+++ b/ConsoleClient/README.md
@@ -20,7 +20,9 @@ Note that you may need to use `sudo docker` below, depending on your OS.
     /bin/bash -c 'cd /go/src/github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient && ./make.bash all' \
   ; cd -
   ```
-This command can also be modified by replacing `all` with `windows`, `linux`, or `osx` as the first parameter to `make.bash` (as in `...&& ./make.bash windows`) to only build binaries for the operating system of choice
+This command can also be modified by:
+ - replacing `all` with `windows`, `linux`, or `osx` as the first parameter to `make.bash` (as in `...&& ./make.bash windows`) to only build binaries for the operating system of choice
+   - if `windows` or `linux` is specified as the first parameter, the second parameter can be passed as either `32` or `64` (as in `...&& ./make.bash windows 32`)to limit the builds to just one or the other (no second parameter means both will build)
 
 When that command completes, the compiled binaries will be located in the `bin` directory (`./bin`, and everything under it will likely be owned by root, so be sure to `chown` to an appropriate user) under the current directory. The structure will be:
   ```

--- a/ConsoleClient/make.bash
+++ b/ConsoleClient/make.bash
@@ -30,34 +30,64 @@ if [ ! -d bin ]; then
   mkdir bin
 fi
 
+
+prep_openssl () {
+  if [ ! -f /tmp/openssl.tar.gz ]; then
+    curl -L https://github.com/Psiphon-Labs/psiphon-tunnel-core/raw/master/openssl/openssl-$OPENSSL_VERSION.tar.gz -o /tmp/openssl.tar.gz
+  fi
+
+  if [ -d /tmp/openssl ]; then
+    rm -rf /tmp/openssl
+  fi
+
+  mkdir -p /tmp/openssl
+  tar -C /tmp/openssl -xzf /tmp/openssl.tar.gz
+}
+
 build_for_windows () {
-  echo "...Getting project dependencies (via go get) for Windows"
+  echo "...Getting project dependencies (via go get) for Windows. Parameter is: '$1'"
   GOOS=windows go get -d -v ./...
 
-  echo "...Building windows-i686"
-  CC=/usr/bin/i686-w64-mingw32-gcc gox -verbose -ldflags "$LDFLAGS" -osarch windows/386 -output bin/windows/${EXE_BASENAME}-i686
-  # We are finding that UPXing the full Windows Psiphon client produces better results if psiphon-tunnel-core.exe is not already UPX'd.
-  echo "....No UPX for this build"
+  if [ -z $1 ] || [ "$1" == "32" ]; then
+    echo "...Building windows-i686"
+    echo "....Preparing clean OpenSSL"
+    prep_openssl
 
-  echo "...Building windows-x86_64"
-  CC=/usr/bin/x86_64-w64-mingw32-gcc gox -verbose -ldflags "$LDFLAGS" -osarch windows/amd64 -output bin/windows/${EXE_BASENAME}-x86_64
-  # We are finding that UPXing the full Windows Psiphon client produces better results if psiphon-tunnel-core.exe is not already UPX'd.
-  echo "....No UPX for this build"
+    cd $PKG_CONFIG_PATH && ./Configure --cross-compile-prefix=i686-w64-mingw32- mingw no-shared no-ssl2 no-ssl3 no-comp no-hw no-md2 no-md4 no-rc2 no-rc5 no-krb5 no-ripemd160 no-idea no-gost no-camellia no-seed no-3des no-heartbeats && make depend && make && cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient || exit 1
+    CGO_CFLAGS="-I $PKG_CONFIG_PATH/include/" CGO_LDFLAGS="-L $PKG_CONFIG_PATH -L /usr/i686-w64-mingw32/lib/ -lssl -lcrypto -lwsock32 -lcrypt32 -lgdi32" CC=/usr/bin/i686-w64-mingw32-gcc gox -verbose -ldflags "$LDFLAGS" -osarch windows/386 -output bin/windows/${EXE_BASENAME}-i686
+    ## We are finding that UPXing the full Windows Psiphon client produces better results if psiphon-tunnel-core.exe is not already UPX'd.
+    echo "....No UPX for this build"
+  fi
+
+  if [ -z $1 ] || [ "$1" == "64" ]; then
+    echo "...Building windows-x86_64"
+    echo "....Preparing clean OpenSSL"
+    prep_openssl
+
+    cd $PKG_CONFIG_PATH && ./Configure --cross-compile-prefix=x86_64-w64-mingw32- mingw64 no-shared no-ssl2 no-ssl3 no-comp no-hw no-md2 no-md4 no-rc2 no-rc5 no-krb5 no-ripemd160 no-idea no-gost no-camellia no-seed no-3des no-heartbeats && make depend && make && cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient || exit 1
+    CGO_CFLAGS="-I $PKG_CONFIG_PATH/include/" CGO_LDFLAGS="-L $PKG_CONFIG_PATH -L /usr/x86_64-w64-mingw32/lib/ -lssl -lcrypto -lwsock32 -lcrypt32 -lgdi32" CC=/usr/bin/x86_64-w64-mingw32-gcc gox -verbose -ldflags "$LDFLAGS" -osarch windows/amd64 -output bin/windows/${EXE_BASENAME}-x86_64
+    # We are finding that UPXing the full Windows Psiphon client produces better results if psiphon-tunnel-core.exe is not already UPX'd.
+    echo "....No UPX for this build"
+  fi
 }
 
 build_for_linux () {
-  echo "Getting project dependencies (via go get) for Linux"
+  echo "Getting project dependencies (via go get) for Linux. Parameter is: '$1'"
   GOOS=linux go get -d -v ./...
 
-  echo "...Building linux-i686"
-  CFLAGS=-m32 gox -verbose -ldflags "$LDFLAGS" -osarch linux/386 -output bin/linux/${EXE_BASENAME}-i686
-  echo "....UPX packaging output"
-  goupx --best bin/linux/${EXE_BASENAME}-i686
+  if [ -z $1 ] || [ "$1" == "32" ]; then
+    echo "...Building linux-i686"
+    CFLAGS=-m32 gox -verbose -ldflags "$LDFLAGS" -osarch linux/386 -output bin/linux/${EXE_BASENAME}-i686
+    echo "....UPX packaging output"
+    goupx --best bin/linux/${EXE_BASENAME}-i686
+  fi
 
-  echo "...Building linux-x86_64"
-  gox -verbose -ldflags "$LDFLAGS" -osarch linux/amd64 -output bin/linux/${EXE_BASENAME}-x86_64
-  echo "....UPX packaging output"
-  goupx --best bin/linux/${EXE_BASENAME}-x86_64
+  if [ -z $1 ] || [ "$1" == "64" ]; then
+    echo "...Building linux-x86_64"
+    gox -verbose -ldflags "$LDFLAGS" -osarch linux/amd64 -output bin/linux/${EXE_BASENAME}-x86_64
+    echo "....UPX packaging output"
+    goupx --best bin/linux/${EXE_BASENAME}-x86_64
+  fi
 }
 
 build_for_osx () {
@@ -65,6 +95,7 @@ build_for_osx () {
   GOOS=darwin go get -d -v ./...
 
   echo "Building darwin-x86_64..."
+  echo "..Disabling CGO for this build"
   CGO_ENABLED=0 gox -verbose -ldflags "$LDFLAGS" -osarch darwin/amd64 -output bin/darwin/${EXE_BASENAME}-x86_64
   # Darwin binaries don't seem to be UPXable when built this way
   echo "..No UPX for this build"
@@ -74,11 +105,11 @@ TARGET=$1
 case $TARGET in
   windows)
     echo "..Building for Windows"
-    build_for_windows
+    build_for_windows $2
     ;;
   linux)
     echo "..Building for Linux"
-    build_for_linux
+    build_for_linux $2
     ;;
   osx)
     echo "..Building for OSX"
@@ -86,14 +117,14 @@ case $TARGET in
     ;;
   all)
     echo "..Building all"
-    build_for_windows
-    build_for_linux
+    build_for_windows $2
+    build_for_linux $2
     build_for_osx
     ;;
   *)
     echo "..No selection made, building all"
-    build_for_windows
-    build_for_linux
+    build_for_windows $2
+    build_for_linux $2
     build_for_osx
     ;;
 

--- a/psiphon/opensslConn.go
+++ b/psiphon/opensslConn.go
@@ -1,4 +1,4 @@
-// +build android
+// +build android windows
 
 /*
  * Copyright (c) 2015, Psiphon Inc.

--- a/psiphon/opensslConn_unsupported.go
+++ b/psiphon/opensslConn_unsupported.go
@@ -1,4 +1,4 @@
-// +build !android
+// +build !android, !windows
 
 /*
  * Copyright (c) 2015, Psiphon Inc.


### PR DESCRIPTION
…; updated make file to accept optional second param (32 or 64) to only build for one architecture (windows/linux builds only)