### PR TITLE
created new 'generate' flags for log filename and fail2ban log filena…

### DIFF
--- a/Server/Dockerfile
+++ b/Server/Dockerfile
@@ -10,8 +10,15 @@ RUN apk add --update \
 
 RUN mkdir -p /opt/psiphon
 
-ADD ["psiphond", "psiphond.config", "psiphond-traffic-rules.config", "/opt/psiphon/"]
+ADD ["psiphond", "/opt/psiphon/"]
 
-WORKDIR /opt/psiphon
+# All configuration files, Server databases, GeoIP databases, etc.
+# should be made available via the `/opt/psiphon/config` volume
+VOLUME ["/opt/psiphon/config", "/var/log/psiphon"]
 
-ENTRYPOINT ["./psiphond", "run"]
+EXPOSE 3000 3001 3002 3003 3004 3005 3006
+
+WORKDIR /opt/psiphon/config
+
+ENTRYPOINT ["/opt/psiphon/psiphond"]
+CMD ["run"]

--- a/Server/Dockerfile-binary-builder
+++ b/Server/Dockerfile-binary-builder
@@ -26,3 +26,5 @@ ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 WORKDIR $GOPATH
+
+CMD ["/go/src/github.com/Psiphon-Labs/psiphon-tunnel-core/Server/make.bash"]

--- a/Server/main.go
+++ b/Server/main.go
@@ -37,6 +37,8 @@ func main() {
 	var generateServerIPaddress, generateServerNetworkInterface string
 	var generateWebServerPort int
 	var generateProtocolPorts stringListFlag
+	var generateLogFilename string
+	var generateFail2BanLogFilename string
 	var configFilename string
 
 	flag.StringVar(
@@ -73,6 +75,18 @@ func main() {
 		&generateProtocolPorts,
 		"protocol",
 		"generate with `protocol:port`; flag may be repeated to enable multiple protocols")
+
+	flag.StringVar(
+		&generateLogFilename,
+		"logFilename",
+		"",
+		"set application log file name and path; blank for stderr")
+
+	flag.StringVar(
+		&generateFail2BanLogFilename,
+		"fail2BanLogFilename",
+		"",
+		"set Fail2Ban log file name and path; blank for stderr")
 
 	flag.StringVar(
 		&configFilename,
@@ -128,6 +142,8 @@ func main() {
 					WebServerPort:        generateWebServerPort,
 					TunnelProtocolPorts:  tunnelProtocolPorts,
 					TrafficRulesFilename: generateTrafficRulesFilename,
+					LogFilename:          generateLogFilename,
+					Fail2BanLogFilename:  generateFail2BanLogFilename,
 				})
 		if err != nil {
 			fmt.Printf("generate failed: %s\n", err)

--- a/Server/make.bash
+++ b/Server/make.bash
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -e
 
@@ -26,12 +26,7 @@ build_for_linux () {
   chmod 555 psiphond
 
   if [ "$1" == "generate" ]; then
-    ./psiphond --ipaddress 0.0.0.0 --protocol SSH:22 --protocol OSSH:53 --web 80 generate
-    # Temporary:
-    #  - Disable syslog integration until final strategy is chosen
-    #  - Disable Fail2Ban integration until final strategy is chosen
-    sed -i 's/"SyslogFacility": "user"/"SyslogFacility": ""/' psiphond.config
-    sed -i 's/"Fail2BanFormat": "Authentication failure for psiphon-client from %s"/"Fail2BanFormat": ""/' psiphond.config
+    ./psiphond --ipaddress 0.0.0.0 --web 3000 --protocol SSH:3001 --protocol OSSH:3002 --logFilename /var/log/psiphon/psiphond.log --fail2BanLogFilename /var/log/psiphon/fail2ban.log generate
 
     chmod 666 psiphond.config
     chmod 666 psiphond-traffic-rules.config

--- a/psiphon/server/config.go
+++ b/psiphon/server/config.go
@@ -319,6 +319,8 @@ type GenerateConfigParams struct {
 	EnableSSHAPIRequests bool
 	TunnelProtocolPorts  map[string]int
 	TrafficRulesFilename string
+	LogFilename          string
+	Fail2BanLogFilename  string
 }
 
 // GenerateConfig creates a new Psiphon server config. It returns JSON
@@ -483,6 +485,8 @@ func GenerateConfig(params *GenerateConfigParams) ([]byte, []byte, []byte, error
 		MeekProxyForwardedForHeaders:   []string{"X-Forwarded-For"},
 		LoadMonitorPeriodSeconds:       300,
 		TrafficRulesFilename:           params.TrafficRulesFilename,
+		LogFilename:                    params.LogFilename,
+		Fail2BanLogFilename:            params.Fail2BanLogFilename,
 	}
 
 	encodedConfig, err := json.MarshalIndent(config, "\n", "    ")


### PR DESCRIPTION
…me; simplified the docker-builder runtime command and updated the documentation; updated docker-runner container to expose correct ports and volumes, as well as using an ENTRYPOINT to call psiphond and a RUN to specify the default parameters ('run')