### PR TITLE
Misc. fixes and cleanups

### DIFF
--- a/psiphon/server/config.go
+++ b/psiphon/server/config.go
@@ -31,7 +31,6 @@ import (
 	"net"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon"
 	"golang.org/x/crypto/nacl/box"
@@ -39,23 +38,16 @@ import (
 )
 
 const (
-	SERVER_CONFIG_FILENAME                = "psiphond.config"
-	SERVER_TRAFFIC_RULES_FILENAME         = "psiphond-traffic-rules.config"
-	SERVER_ENTRY_FILENAME                 = "server-entry.dat"
-	DEFAULT_SERVER_IP_ADDRESS             = "127.0.0.1"
-	WEB_SERVER_SECRET_BYTE_LENGTH         = 32
-	DISCOVERY_VALUE_KEY_BYTE_LENGTH       = 32
-	WEB_SERVER_READ_TIMEOUT               = 10 * time.Second
-	WEB_SERVER_WRITE_TIMEOUT              = 10 * time.Second
-	SSH_USERNAME_SUFFIX_BYTE_LENGTH       = 8
-	SSH_PASSWORD_BYTE_LENGTH              = 32
-	SSH_RSA_HOST_KEY_BITS                 = 2048
-	SSH_HANDSHAKE_TIMEOUT                 = 30 * time.Second
-	SSH_CONNECTION_READ_DEADLINE          = 5 * time.Minute
-	SSH_TCP_PORT_FORWARD_DIAL_TIMEOUT     = 30 * time.Second
-	SSH_TCP_PORT_FORWARD_COPY_BUFFER_SIZE = 8192
-	SSH_OBFUSCATED_KEY_BYTE_LENGTH        = 32
-	GEOIP_SESSION_CACHE_TTL               = 60 * time.Minute
+	SERVER_CONFIG_FILENAME          = "psiphond.config"
+	SERVER_TRAFFIC_RULES_FILENAME   = "psiphond-traffic-rules.config"
+	SERVER_ENTRY_FILENAME           = "server-entry.dat"
+	DEFAULT_SERVER_IP_ADDRESS       = "127.0.0.1"
+	WEB_SERVER_SECRET_BYTE_LENGTH   = 32
+	DISCOVERY_VALUE_KEY_BYTE_LENGTH = 32
+	SSH_USERNAME_SUFFIX_BYTE_LENGTH = 8
+	SSH_PASSWORD_BYTE_LENGTH        = 32
+	SSH_RSA_HOST_KEY_BITS           = 2048
+	SSH_OBFUSCATED_KEY_BYTE_LENGTH  = 32
 )
 
 // Config specifies the configuration and behavior of a Psiphon

--- a/psiphon/server/geoip.go
+++ b/psiphon/server/geoip.go
@@ -30,7 +30,10 @@ import (
 	"github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon"
 )
 
-const UNKNOWN_GEOIP_VALUE = "None"
+const (
+	GEOIP_SESSION_CACHE_TTL = 60 * time.Minute
+	GEOIP_UNKNOWN_VALUE     = "None"
+)
 
 // GeoIPData is GeoIP data for a client session. Individual client
 // IP addresses are neither logged nor explicitly referenced during a session.
@@ -46,12 +49,12 @@ type GeoIPData struct {
 }
 
 // NewGeoIPData returns a GeoIPData initialized with the expected
-// UNKNOWN_GEOIP_VALUE values to be used when GeoIP lookup fails.
+// GEOIP_UNKNOWN_VALUE values to be used when GeoIP lookup fails.
 func NewGeoIPData() GeoIPData {
 	return GeoIPData{
-		Country: UNKNOWN_GEOIP_VALUE,
-		City:    UNKNOWN_GEOIP_VALUE,
-		ISP:     UNKNOWN_GEOIP_VALUE,
+		Country: GEOIP_UNKNOWN_VALUE,
+		City:    GEOIP_UNKNOWN_VALUE,
+		ISP:     GEOIP_UNKNOWN_VALUE,
 	}
 }
 

--- a/psiphon/server/server_test.go
+++ b/psiphon/server/server_test.go
@@ -109,9 +109,14 @@ func runServer(t *testing.T, runConfig *runServerConfig) {
 
 	// create a server
 
+	serverIPaddress, err := psiphon.GetInterfaceIPAddress("en0")
+	if err != nil {
+		t.Fatalf("error getting server IP address: %s", err)
+	}
+
 	serverConfigJSON, _, encodedServerEntry, err := GenerateConfig(
 		&GenerateConfigParams{
-			ServerIPAddress:      "127.0.0.1",
+			ServerIPAddress:      serverIPaddress,
 			EnableSSHAPIRequests: runConfig.enableSSHAPIRequests,
 			WebServerPort:        8000,
 			TunnelProtocolPorts:  map[string]int{runConfig.tunnelProtocol: 4000},

--- a/psiphon/server/webServer.go
+++ b/psiphon/server/webServer.go
@@ -28,9 +28,12 @@ import (
 	"net"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon"
 )
+
+const WEB_SERVER_IO_TIMEOUT = 10 * time.Second
 
 type webServer struct {
 	support  *SupportServices
@@ -80,13 +83,16 @@ func RunWebServer(
 	logWriter := NewLogWriter()
 	defer logWriter.Close()
 
+	// Note: WriteTimeout includes time awaiting request, as per:
+	// https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts
+
 	server := &psiphon.HTTPSServer{
 		http.Server{
 			MaxHeaderBytes: MAX_API_PARAMS_SIZE,
 			Handler:        serveMux,
 			TLSConfig:      tlsConfig,
-			ReadTimeout:    WEB_SERVER_READ_TIMEOUT,
-			WriteTimeout:   WEB_SERVER_WRITE_TIMEOUT,
+			ReadTimeout:    WEB_SERVER_IO_TIMEOUT,
+			WriteTimeout:   WEB_SERVER_IO_TIMEOUT,
 			ErrorLog:       golanglog.New(logWriter, "", 0),
 		},
 	}


### PR DESCRIPTION
* Dispersed constants to related source files.
* Have both types of I/O timeout on idle ActivityMonitoredConn.
* Use single client I/O timeout value for http.Server due to
  WriteTimeout period; document issue.
* Explicitly use only read activity for GetActiveDuration; document
  reason.
* In ActivityMonitoredConn, actually check Set[...]Deadline return
  value (as it was failing, although not a problem in practice).
* meekConn.SetDeadline documents idle timeout situation and checks
  that ActivityMonitoredConn functionality is accommodated.
* Explicitly prohibit port forwards to localhost and loopback (in case
  this isn't handled by iptables or containerization).
* rejectNewChannel now returns minimal info to client.