### PR TITLE
Revert 0dfb771

### DIFF
--- a/Server/make.bash
+++ b/Server/make.bash
@@ -54,7 +54,7 @@ build_for_linux () {
     exit $?
   fi
 
-  GOOS=linux GOARCH=amd64 go build -race -ldflags "$LDFLAGS" -o psiphond main.go
+  GOOS=linux GOARCH=amd64 go build -ldflags "$LDFLAGS" -o psiphond main.go
   if [ $? != 0 ]; then
     echo "...'go build' failed, exiting"
     exit $?


### PR DESCRIPTION
- Fails to build in Docker environment: "undefined reference to `__libc_malloc'", etc.
- Issue with Alpine Linux/MUSL libc: https://groups.google.com/forum/#!topic/golang-nuts/WnfKCoaRP_E