### PR TITLE
Fix: legacy clients expect empty arrays, not null, in handshake response

### DIFF
--- a/psiphon/server/api.go
+++ b/psiphon/server/api.go
@@ -171,6 +171,7 @@ func handshakeAPIRequestHandler(
 	handshakeResponse := common.HandshakeResponse{
 		Homepages:            db.GetRandomHomepage(sponsorID, geoIPData.Country, isMobile),
 		UpgradeClientVersion: db.GetUpgradeClientVersion(clientVersion, normalizedPlatform),
+		PageViewRegexes:      make([]map[string]string, 0),
 		HttpsRequestRegexes:  db.GetHttpsRequestRegexes(sponsorID),
 		EncodedServerList:    db.DiscoverServers(geoIPData.DiscoveryValue),
 		ClientRegion:         geoIPData.Country,

--- a/psiphon/server/psinet/psinet.go
+++ b/psiphon/server/psinet/psinet.go
@@ -157,9 +157,9 @@ func (db *Database) GetRandomHomepage(sponsorID, clientRegion string, isMobilePl
 	homepages := db.GetHomepages(sponsorID, clientRegion, isMobilePlatform)
 	if len(homepages) > 0 {
 		index := rand.Intn(len(homepages))
-		return homepages[index:index+1]
+		return homepages[index : index+1]
 	}
-	return nil
+	return homepages
 }
 
 // GetHomepages returns a list of home pages for the specified sponsor,


### PR DESCRIPTION
response.