### PR TITLE
Make OpenSSL compilation conditional on all platforms.

### DIFF
--- a/MobileLibrary/iOS/build-psiphon-framework.sh
+++ b/MobileLibrary/iOS/build-psiphon-framework.sh
@@ -200,7 +200,7 @@ IOS_CGO_BUILD_FLAGS='// #cgo darwin CFLAGS: -I'"${OPENSSL_INCLUDE}"'\
 
 LC_ALL=C sed -i -- "s|// #cgo pkg-config: libssl|${IOS_CGO_BUILD_FLAGS}|" "${OPENSSL_SRC_DIR}/build.go"
 
-${GOPATH}/bin/gomobile bind -target ios -ldflags="${LDFLAGS}" -o "${INTERMEDIATE_OUPUT_DIR}/${INTERMEDIATE_OUPUT_FILE}" github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/psi
+${GOPATH}/bin/gomobile bind -v -x -target ios -tags="OPENSSL IOS" -ldflags="${LDFLAGS}" -o "${INTERMEDIATE_OUPUT_DIR}/${INTERMEDIATE_OUPUT_FILE}" github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/psi
 rc=$?; if [[ $rc != 0 ]]; then
   echo "FAILURE: ${GOPATH}/bin/gomobile bind -target ios -ldflags="${LDFLAGS}" -o "${INTERMEDIATE_OUPUT_DIR}/${INTERMEDIATE_OUPUT_FILE}" github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/psi"
   exit $rc

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Client Setup
 
 ##### macOS
 
+Building without OpenSSL support (that is, without indistinguishable TLS support) requires no extra steps. 
+To compile with OpenSSL support, follow these steps:
+
 1. You must have [Homebrew](http://brew.sh/) installed.
 
 2. `brew install openssl pkg-config`
@@ -58,10 +61,11 @@ Client Setup
    
    Make note of the "build variable" path for `PKG_CONFIG_PATH`.
    
-4. Set `PKG_CONFIG_PATH=<path discovered above>` when building. This can be easily done on the build command line like so:
+4. Set `PKG_CONFIG_PATH=<path discovered above>` when building, and provide the `-tags OPENSSL` flag. 
+   This can be easily done on the build command line like so:
 
    ```
-   $ PKG_CONFIG_PATH=<path discovered above> go build
+   $ PKG_CONFIG_PATH=<path discovered above> go build -tags OPENSSL
    ```
 
 ### Configure

--- a/psiphon/opensslConn.go
+++ b/psiphon/opensslConn.go
@@ -1,4 +1,4 @@
-// +build android windows darwin
+// +build OPENSSL
 
 /*
  * Copyright (c) 2015, Psiphon Inc.

--- a/psiphon/opensslConn_unsupported.go
+++ b/psiphon/opensslConn_unsupported.go
@@ -1,4 +1,4 @@
-// +build !android,!windows,!darwin
+// +build !OPENSSL
 
 /*
  * Copyright (c) 2015, Psiphon Inc.


### PR DESCRIPTION
This makes it much easier to pull source and build on macOS and Windows without setting up an OpenSSL dev environment.

These changes are also necessary to work with Psiphon-Inc/openssl@1c2f96a22ba068517212345b1a871d94b8d965d7