### PR TITLE
Add obfuscated server list functionality to iOS library

### DIFF
--- a/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel/PsiphonTunnel.h
+++ b/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel/PsiphonTunnel.h
@@ -56,8 +56,9 @@ FOUNDATION_EXPORT const unsigned char PsiphonTunnelVersionString[];
    - `ObfuscatedServerListRootURL`
 
  Optional fields (if you don't need them, don't set them):
- - `DataStoreDirectory`: If not set, the library will use a sane location. Override if the client wants to restrict where operational data is kept.
- - `RemoteServerListDownloadFilename`: See comment for `DataStoreDirectory`.
+ - `DataStoreDirectory`: If not set, the library will use a sane location. Override if the client wants to restrict where operational data is kept. If overridden, the directory must already exist and be writable.
+ - `RemoteServerListDownloadFilename`: If not set, the library will use a sane location. Override if the client wants to restrict where operational data is kept.
+ - `ObfuscatedServerListDownloadDirectory`: If not set, the library will use a sane location. Override if the client wants to restrict where operational data is kept. If overridden, the directory must already exist and be writable.
  - `ClientPlatform`: Should not be set by most library consumers.
  - `UpstreamProxyUrl`
  - `EmitDiagnosticNotices`

--- a/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel/PsiphonTunnel.h
+++ b/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel/PsiphonTunnel.h
@@ -52,6 +52,8 @@ FOUNDATION_EXPORT const unsigned char PsiphonTunnelVersionString[];
  - Remote server list functionality is not strictly required, but absence greatly undermines circumvention ability.
    - `RemoteServerListUrl`
    - `RemoteServerListSignaturePublicKey`
+ - Obfuscated server list functionality is also not strictly required, but aids circumvention ability.
+   - `ObfuscatedServerListRootURL`
 
  Optional fields (if you don't need them, don't set them):
  - `DataStoreDirectory`: If not set, the library will use a sane location. Override if the client wants to restrict where operational data is kept.

--- a/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel/PsiphonTunnel.m
+++ b/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel/PsiphonTunnel.m
@@ -205,11 +205,15 @@
         [self logMessage:[NSString stringWithFormat: @"DataStoreDirectory overridden from '%@' to '%@'", [defaultDataStoreDirectoryURL path], config[@"DataStoreDirectory"]]];
     }
     
-    // See previous comment.
     NSString *defaultRemoteServerListFilename = [[libraryURL URLByAppendingPathComponent:@"remote_server_list" isDirectory:NO] path];
-    
     if (defaultRemoteServerListFilename == nil) {
         [self logMessage:@"Unable to create defaultRemoteServerListFilename"];
+        return nil;
+    }
+    
+    NSString *defaultOSLDirectory = [[libraryURL URLByAppendingPathComponent:@"osl" isDirectory:YES] path];
+    if (defaultOSLDirectory == nil) {
+        [self logMessage:@"Unable to create defaultOSLDirectory"];
         return nil;
     }
     
@@ -225,6 +229,18 @@
     if (config[@"RemoteServerListUrl"] == nil ||
         config[@"RemoteServerListSignaturePublicKey"] == nil) {
         [self logMessage:@"Remote server list functionality will be disabled"];
+    }
+    
+    if (config[@"ObfuscatedServerListDownloadDirectory"] == nil) {
+        config[@"ObfuscatedServerListDownloadDirectory"] = defaultOSLDirectory;
+    }
+    else {
+        [self logMessage:[NSString stringWithFormat: @"ObfuscatedServerListDownloadDirectory overridden from '%@' to '%@'", defaultOSLDirectory, config[@"ObfuscatedServerListDownloadDirectory"]]];
+    }
+    
+    // If ObfuscatedServerListRootURL is absent, we'll leave it out, but log the absence.
+    if (config[@"ObfuscatedServerListRootURL"] == nil) {
+        [self logMessage:@"Obfuscated server list functionality will be disabled"];
     }
 
     // Other optional fields not being altered. If not set, their defaults will be used:

--- a/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel/PsiphonTunnel.m
+++ b/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel/PsiphonTunnel.m
@@ -183,6 +183,10 @@
         return nil;
     }
     
+    //
+    // DataStoreDirectory
+    //
+    
     // Some clients will have a data directory that they'd prefer the Psiphon
     // library use, but if not we'll default to the user Library directory.
     NSURL *defaultDataStoreDirectoryURL = [libraryURL URLByAppendingPathComponent:@"datastore" isDirectory:YES];
@@ -205,15 +209,13 @@
         [self logMessage:[NSString stringWithFormat: @"DataStoreDirectory overridden from '%@' to '%@'", [defaultDataStoreDirectoryURL path], config[@"DataStoreDirectory"]]];
     }
     
+    //
+    // Remote Server List
+    //
+    
     NSString *defaultRemoteServerListFilename = [[libraryURL URLByAppendingPathComponent:@"remote_server_list" isDirectory:NO] path];
     if (defaultRemoteServerListFilename == nil) {
         [self logMessage:@"Unable to create defaultRemoteServerListFilename"];
-        return nil;
-    }
-    
-    NSString *defaultOSLDirectory = [[libraryURL URLByAppendingPathComponent:@"osl" isDirectory:YES] path];
-    if (defaultOSLDirectory == nil) {
-        [self logMessage:@"Unable to create defaultOSLDirectory"];
         return nil;
     }
     
@@ -231,11 +233,27 @@
         [self logMessage:@"Remote server list functionality will be disabled"];
     }
     
+    //
+    // Obfuscated Server List
+    //
+    
+    NSURL *defaultOSLDirectoryURL = [libraryURL URLByAppendingPathComponent:@"osl" isDirectory:YES];
+    if (defaultOSLDirectoryURL == nil) {
+        [self logMessage:@"Unable to create defaultOSLDirectory"];
+        return nil;
+    }
+    
     if (config[@"ObfuscatedServerListDownloadDirectory"] == nil) {
-        config[@"ObfuscatedServerListDownloadDirectory"] = defaultOSLDirectory;
+        [fileManager createDirectoryAtURL:defaultOSLDirectoryURL withIntermediateDirectories:YES attributes:nil error:&err];
+        if (err != nil) {
+            [self logMessage:[NSString stringWithFormat: @"Unable to create defaultOSLDirectoryURL: %@", err.localizedDescription]];
+            return nil;
+        }
+        
+        config[@"ObfuscatedServerListDownloadDirectory"] = [defaultOSLDirectoryURL path];
     }
     else {
-        [self logMessage:[NSString stringWithFormat: @"ObfuscatedServerListDownloadDirectory overridden from '%@' to '%@'", defaultOSLDirectory, config[@"ObfuscatedServerListDownloadDirectory"]]];
+        [self logMessage:[NSString stringWithFormat: @"ObfuscatedServerListDownloadDirectory overridden from '%@' to '%@'", [defaultOSLDirectoryURL path], config[@"ObfuscatedServerListDownloadDirectory"]]];
     }
     
     // If ObfuscatedServerListRootURL is absent, we'll leave it out, but log the absence.


### PR DESCRIPTION
Based on the changes made to the Android code:
https://bitbucket.org/psiphon/psiphon-circumvention-system/commits/94654a9c4a1da535a353a3d124d5fcf99ea917a8?at=default