### PR TITLE
Make a zip to use as build artifact (to avoid Jenkins breaking it)

### DIFF
--- a/MobileLibrary/iOS/build-psiphon-framework.sh
+++ b/MobileLibrary/iOS/build-psiphon-framework.sh
@@ -252,4 +252,10 @@ fi
 # Delete the temporary simulator build files.
 rm -rf "${BUILD_DIR}-SIMULATOR"
 
+# Jenkins loses symlinks from the framework directory, which results in a build
+# artifact that is invalid to use in an App Store app. Instead, we will zip the
+# resulting build and use that as the artifact.
+cd "${BUILD_DIR}"
+zip --recurse-paths --symlinks build.zip * --exclude "*.DS_Store"
+
 echo "BUILD DONE"


### PR DESCRIPTION
Jenkins duplicates files rather than respecting symlinks, and that results in a framework that the App Store will not accept. Issues: [JENKINS-5993](https://issues.jenkins-ci.org/browse/JENKINS-5993), [JENKINS-5597](https://issues.jenkins-ci.org/browse/JENKINS-5597)