### PR TITLE
Attempt to reduce test failures due to requesting from external service

### DIFF
--- a/psiphon/controller_test.go
+++ b/psiphon/controller_test.go
@@ -834,7 +834,13 @@ func fetchAndVerifyWebsite(t *testing.T, httpProxyPort int) {
 		Timeout: roundTripTimeout,
 	}
 
-	response, err := httpClient.Get(testUrl)
+	request, err := http.NewRequest("GET", testUrl, nil)
+	if err != nil {
+		t.Fatalf("error preparing proxied HTTP request: %s", err)
+	}
+	request.Close = true
+
+	response, err := httpClient.Do(request)
 	if err != nil {
 		t.Fatalf("error sending proxied HTTP request: %s", err)
 	}
@@ -849,6 +855,9 @@ func fetchAndVerifyWebsite(t *testing.T, httpProxyPort int) {
 		t.Fatalf("unexpected proxied HTTP response")
 	}
 
+	// Delay before requesting from external service again
+	time.Sleep(1 * time.Second)
+
 	// Test: use direct URL proxy
 
 	httpClient = &http.Client{
@@ -856,9 +865,17 @@ func fetchAndVerifyWebsite(t *testing.T, httpProxyPort int) {
 		Timeout:   roundTripTimeout,
 	}
 
-	response, err = httpClient.Get(
+	request, err = http.NewRequest(
+		"GET",
 		fmt.Sprintf("http://127.0.0.1:%d/direct/%s",
-			httpProxyPort, url.QueryEscape(testUrl)))
+			httpProxyPort, url.QueryEscape(testUrl)),
+		nil)
+	if err != nil {
+		t.Fatalf("error preparing direct URL request: %s", err)
+	}
+	request.Close = true
+
+	response, err = httpClient.Do(request)
 	if err != nil {
 		t.Fatalf("error sending direct URL request: %s", err)
 	}


### PR DESCRIPTION
- Intermittent error controller_test.go:832: error sending proxied HTTP request:
Get https://raw.githubusercontent.com/Psiphon-Labs/psiphon-tunnel-core/master/LICENSE:
unexpected EOF
- Try explicitly closing persistent connections and adding a short delay between
back-to-back requests
- Eventually, we should mock the upstream web server and not use and external
service