### PR TITLE
Do not log reachability flags

### DIFF
--- a/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel/Reachability/Reachability.m
+++ b/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel/Reachability/Reachability.m
@@ -25,7 +25,7 @@ NSString *kReachabilityChangedNotification = @"kNetworkReachabilityChangedNotifi
 
 #pragma mark - Supporting functions
 
-#define kShouldPrintReachabilityFlags 1
+#define kShouldPrintReachabilityFlags 0
 
 static void PrintReachabilityFlags(SCNetworkReachabilityFlags flags, const char* comment)
 {


### PR DESCRIPTION
Reduce unnecessary log noise