### PR TITLE
Update stub with multi-URL config params

### DIFF
--- a/MobileLibrary/Android/SampleApps/TunneledWebView/app/src/main/res/raw/psiphon_config_stub
+++ b/MobileLibrary/Android/SampleApps/TunneledWebView/app/src/main/res/raw/psiphon_config_stub
@@ -1,8 +1,16 @@
+/*
+These are the minimum values required to use the Psiphon Tunnel.
+ClientVersion is the version number of your software, which will be tracked in Psiphon stats.
+All other values will be provided to you by Psiphon Inc.
+*/
+
 {
-    "PropagationChannelId" : "<placeholder>",
-    "SponsorId" : "<placeholder>",
-    "RemoteServerListUrl" : "<placeholder>",
-    "RemoteServerListSignaturePublicKey" : "<placeholder>",
+    "ClientVersion": "123", /* Must be a number in a string. */
+    "PropagationChannelId" : "...",
+    "SponsorId" : "...",
+    "RemoteServerListURLs": "[...]",
+    "RemoteServerListSignaturePublicKey" : "...",
+    "ObfuscatedServerListRootURLs": "[...]",
     "DataStoreDirectory" : "",
     "DataStoreTempDirectory" : "",
     "LogFilename" : "",
@@ -13,5 +21,6 @@
     "ConnectionWorkerPoolSize" : 10,
     "TunnelPoolSize" : 1,
     "PortForwardFailureThreshold" : 10,
-    "UpstreamProxyUrl" : ""
+    "UpstreamProxyUrl" : "",
+    "EmitDiagnosticNotices": true /* Useful when testing */
 }


### PR DESCRIPTION
Compare to the iOS stub:
https://github.com/adam-p/psiphon-tunnel-core/blob/ios-beta/MobileLibrary/iOS/SampleApps/TunneledWebRequest/TunneledWebRequest/psiphon-config.json.stub

I left all the original fields, even though I'm not sure they should be there for the sample.