### PR TITLE
Fix: cancel timers when no longer needed

### DIFF
--- a/psiphon/meekConn.go
+++ b/psiphon/meekConn.go
@@ -629,6 +629,7 @@ func (meek *MeekConn) relay() {
 		MIN_POLL_INTERVAL_JITTER)
 
 	timeout := time.NewTimer(interval)
+	defer timeout.Stop()
 
 	for {
 		timeout.Reset(interval)
@@ -954,6 +955,7 @@ func (meek *MeekConn) roundTrip(sendBuffer *bytes.Buffer) (int64, error) {
 		select {
 		case <-delayTimer.C:
 		case <-meek.runContext.Done():
+			delayTimer.Stop()
 			return 0, common.ContextError(err)
 		}
 

--- a/psiphon/meekConn.go
+++ b/psiphon/meekConn.go
@@ -724,14 +724,19 @@ func (meek *MeekConn) relay() {
 // RoundTrip has called Close and will no longer use the buffer.
 // See: https://golang.org/pkg/net/http/#RoundTripper
 type readCloseSignaller struct {
-	reader io.Reader
-	closed chan struct{}
+	context context.Context
+	reader  io.Reader
+	closed  chan struct{}
 }
 
-func NewReadCloseSignaller(reader io.Reader) *readCloseSignaller {
+func NewReadCloseSignaller(
+	context context.Context,
+	reader io.Reader) *readCloseSignaller {
+
 	return &readCloseSignaller{
-		reader: reader,
-		closed: make(chan struct{}, 1),
+		context: context,
+		reader:  reader,
+		closed:  make(chan struct{}, 1),
 	}
 }
 
@@ -747,8 +752,13 @@ func (r *readCloseSignaller) Close() error {
 	return nil
 }
 
-func (r *readCloseSignaller) AwaitClosed() {
-	<-r.closed
+func (r *readCloseSignaller) AwaitClosed() bool {
+	select {
+	case <-r.context.Done():
+	case <-r.closed:
+		return true
+	}
+	return false
 }
 
 // roundTrip configures and makes the actual HTTP POST request
@@ -817,7 +827,7 @@ func (meek *MeekConn) roundTrip(sendBuffer *bytes.Buffer) (int64, error) {
 			// still reading the current round trip response. signaller provides
 			// the hook for awaiting RoundTrip's call to Close.
 
-			signaller = NewReadCloseSignaller(bytes.NewReader(sendBuffer.Bytes()))
+			signaller = NewReadCloseSignaller(meek.runContext, bytes.NewReader(sendBuffer.Bytes()))
 			requestBody = signaller
 			contentLength = sendBuffer.Len()
 		}
@@ -865,7 +875,14 @@ func (meek *MeekConn) roundTrip(sendBuffer *bytes.Buffer) (int64, error) {
 		// subsequently replace sendBuffer in both the success and
 		// error cases.
 		if signaller != nil {
-			signaller.AwaitClosed()
+			if !signaller.AwaitClosed() {
+				// AwaitClosed encountered Done(). Abort immediately. Do not
+				// replace sendBuffer, as we cannot be certain RoundTrip is
+				// done with it. MeekConn.Write will exit on Done and not hang
+				// awaiting sendBuffer.
+				sendBuffer = nil
+				return 0, common.ContextError(errors.New("meek connection has closed"))
+			}
 		}
 
 		if err != nil {

--- a/psiphon/tlsDialer.go
+++ b/psiphon/tlsDialer.go
@@ -195,9 +195,10 @@ func CustomTLSDial(network, addr string, config *CustomTLSConfig) (net.Conn, err
 	var errChannel chan error
 	if config.Timeout != 0 {
 		errChannel = make(chan error, 2)
-		time.AfterFunc(config.Timeout, func() {
+		timeoutFunc := time.AfterFunc(config.Timeout, func() {
 			errChannel <- errors.New("timed out")
 		})
+		defer timeoutFunc.Stop()
 	}
 
 	dialAddr := addr

--- a/psiphon/tunnel.go
+++ b/psiphon/tunnel.go
@@ -1222,12 +1222,15 @@ func (tunnel *Tunnel) operateTunnel(tunnelOwner TunnelOwner) {
 					return
 				}
 				timer := time.NewTimer(PSIPHON_API_CLIENT_VERIFICATION_REQUEST_RETRY_PERIOD)
+				doReturn := false
 				select {
 				case <-timer.C:
 				case clientVerificationPayload = <-tunnel.newClientVerificationPayload:
-					timer.Stop()
 				case <-signalStopClientVerificationRequests:
-					timer.Stop()
+					doReturn = true
+				}
+				timer.Stop()
+				if doReturn {
 					return
 				}
 			}

--- a/psiphon/tunnel.go
+++ b/psiphon/tunnel.go
@@ -243,6 +243,9 @@ func (tunnel *Tunnel) Activate(
 				tunnel.Close(true)
 				<-resultChannel
 			}
+
+			timer.Stop()
+
 		} else {
 
 			select {
@@ -319,10 +322,10 @@ func (tunnel *Tunnel) Close(isDiscarded bool) {
 		// precedence over the PSIPHON_API_SERVER_TIMEOUT http.Client.Timeout
 		// value set in makePsiphonHttpsClient.
 		if isActivated {
-			timer := time.AfterFunc(TUNNEL_OPERATE_SHUTDOWN_TIMEOUT, func() { tunnel.conn.Close() })
+			afterFunc := time.AfterFunc(TUNNEL_OPERATE_SHUTDOWN_TIMEOUT, func() { tunnel.conn.Close() })
 			close(tunnel.shutdownOperateBroadcast)
 			tunnel.operateWaitGroup.Wait()
-			timer.Stop()
+			afterFunc.Stop()
 		}
 		tunnel.sshClient.Close()
 		// tunnel.conn.Close() may get called multiple times, which is allowed.
@@ -385,9 +388,10 @@ func (tunnel *Tunnel) Dial(
 	}
 	resultChannel := make(chan *tunnelDialResult, 2)
 	if *tunnel.config.TunnelPortForwardDialTimeoutSeconds > 0 {
-		time.AfterFunc(time.Duration(*tunnel.config.TunnelPortForwardDialTimeoutSeconds)*time.Second, func() {
+		afterFunc := time.AfterFunc(time.Duration(*tunnel.config.TunnelPortForwardDialTimeoutSeconds)*time.Second, func() {
 			resultChannel <- &tunnelDialResult{nil, errors.New("tunnel dial timeout")}
 		})
+		defer afterFunc.Stop()
 	}
 	go func() {
 		sshPortForwardConn, err := tunnel.sshClient.Dial("tcp", remoteAddr)
@@ -990,9 +994,10 @@ func dialSsh(
 	}
 	resultChannel := make(chan *sshNewClientResult, 2)
 	if *config.TunnelConnectTimeoutSeconds > 0 {
-		time.AfterFunc(time.Duration(*config.TunnelConnectTimeoutSeconds)*time.Second, func() {
+		afterFunc := time.AfterFunc(time.Duration(*config.TunnelConnectTimeoutSeconds)*time.Second, func() {
 			resultChannel <- &sshNewClientResult{nil, nil, errors.New("ssh dial timeout")}
 		})
+		defer afterFunc.Stop()
 	}
 
 	go func() {
@@ -1216,11 +1221,13 @@ func (tunnel *Tunnel) operateTunnel(tunnelOwner TunnelOwner) {
 				if failCount > PSIPHON_API_CLIENT_VERIFICATION_REQUEST_MAX_RETRIES {
 					return
 				}
-				timeout := time.After(PSIPHON_API_CLIENT_VERIFICATION_REQUEST_RETRY_PERIOD)
+				timer := time.NewTimer(PSIPHON_API_CLIENT_VERIFICATION_REQUEST_RETRY_PERIOD)
 				select {
-				case <-timeout:
+				case <-timer.C:
 				case clientVerificationPayload = <-tunnel.newClientVerificationPayload:
+					timer.Stop()
 				case <-signalStopClientVerificationRequests:
+					timer.Stop()
 					return
 				}
 			}
@@ -1430,9 +1437,10 @@ func sendSshKeepAlive(
 
 	errChannel := make(chan error, 2)
 	if timeout > 0 {
-		time.AfterFunc(timeout, func() {
+		afterFunc := time.AfterFunc(timeout, func() {
 			errChannel <- errors.New("timed out")
 		})
+		defer afterFunc.Stop()
 	}
 
 	go func() {


### PR DESCRIPTION
Always call Timer.Stop to ensure timer resources are cleaned up
when a timer or Timer.AfterFunc is no longer needed. Don't use
time.After, as it provides no way to cancel its timer.

One serious case was Controller.connectedReporter, which started
but never canceled a timer after every connected event. Since the
timer duration in that case is 24 hours, many unnecessary timer
objects would accumulate when frequently reconnecting.