### PR TITLE
fixed bug when stale parameter appears but it's set to "false"

### DIFF
--- a/contributors/gilcu3.md
+++ b/contributors/gilcu3.md
@@ -1,0 +1,9 @@
+2017-12-21
+
+I hereby agree to the terms of the "Psiphon Individual Contributor License Agreement", with MD5 checksum 83d54c85a43e0c0f416758779ea6740a.
+
+I furthermore declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Reynaldo Gil https://github.com/gilcu3

--- a/psiphon/upstreamproxy/auth_digest.go
+++ b/psiphon/upstreamproxy/auth_digest.go
@@ -158,7 +158,7 @@ func (a *DigestHttpAuthenticator) Authenticate(req *http.Request, resp *http.Res
 
 	algorithm := digestParams["algorithm"]
 
-	if _, ok := digestParams["stale"]; ok {
+	if stale, ok := digestParams["stale"]; ok && stale == "true" {
 		// Server indicated that the nonce is stale
 		// Reset auth cache and state
 		a.digestHeaders = nil


### PR DESCRIPTION
in the upstreamproxy package, http proxy with digest auth, the implementation expects stale parameter to be true, or non existent, while it could be set to false. This small difference made it fail to authenticate with current squid proxy.