### PR TITLE
typo in a comment

### DIFF
--- a/contributors/joelanders.md
+++ b/contributors/joelanders.md
@@ -1,0 +1,9 @@
+2017-01-17
+
+I hereby agree to the terms of the "Psiphon Individual Contributor License Agreement", with MD5 checksum 83d54c85a43e0c0f416758779ea6740a.
+
+I furthermore declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Joe Landers https://github.com/joelanders

--- a/psiphon/config.go
+++ b/psiphon/config.go
@@ -108,11 +108,11 @@ type Config struct {
 	// typically embedded in the client binary.
 	PropagationChannelId string
 
-	// PropagationChannelId is a string identifier which indicates who
-	// is sponsoring this Psiphon client. One purpose of this value is to
-	// determine the home pages for display. This parameter is required.
-	// This value is supplied by and depends on the Psiphon Network, and is
-	// typically embedded in the client binary.
+	// SponsorId is a string identifier which indicates who is sponsoring this
+	// Psiphon client. One purpose of this value is to determine the home pages
+	// for display. This parameter is required. This value is supplied by and
+	// depends on the Psiphon Network, and is typically embedded in the client
+	// binary.
 	SponsorId string
 
 	// RemoteServerListUrl is a URL which specifies a location to fetch


### PR DESCRIPTION
`s/PropagationChannelId/SponsorId/` and a re-wrap of the paragraph.