### PR TITLE
Bug fix: persist local SOCKS port when restarting tunnel

### DIFF
--- a/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
+++ b/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
@@ -536,7 +536,7 @@ public class PsiphonTunnel extends Psi.PsiphonProvider.Stub {
 
         json.put("EmitBytesTransferred", true);
 
-        if (mLocalSocksProxyPort.get() != 0 && !json.has("LocalSocksProxyPort")) {
+        if (mLocalSocksProxyPort.get() != 0 && (!json.has("LocalSocksProxyPort") || json.getInt("LocalSocksProxyPort") == 0)) {
             // When mLocalSocksProxyPort is set, tun2socks is already configured
             // to use that port value. So we force use of the same port.
             // A side-effect of this is that changing the SOCKS port preference


### PR DESCRIPTION
not only if LocalProxyPort is not set in the config but
also if LocalProxyPort is present and set to 0