### PR TITLE
Fix: handle all connection states

### DIFF
--- a/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel/PsiphonTunnel.m
+++ b/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel/PsiphonTunnel.m
@@ -325,6 +325,10 @@
 - (BOOL)startIfNeeded {
     PsiphonConnectionState connState = [self getConnectionState];
 
+    if (connState == PsiphonConnectionStateDisconnected) {
+        return [self start];
+    }
+
     // We have found that on iOS, the local proxies will get killed before the
     // tunnel gets disconnected (or before it realizes it's dead). So we need to
     // start if we either in a disconnected state or if our local proxies are dead.
@@ -341,8 +345,7 @@
         needRestart = (httpProxyPort != 0 && ![self isLocalProxyAliveAtPort:httpProxyPort]);
     }
 
-    if ((connState == PsiphonConnectionStateDisconnected) ||
-        (connState == PsiphonConnectionStateConnected && needRestart)) {
+    if (needRestart) {
         return [self start];
     }
 


### PR DESCRIPTION
- The tunnel should be restarted if startIfNeeded is true
  and PsiphonTunnel is in the connecting or waiting for
  network state.

- Previously the local proxies could be dead with PsiphonTunnel
  in the connecting or waiting for network state; in this scenario
  startIfNeeded would incorrectly not restart the tunnel. This
  would result in the proxies remaining dead.