### PR TITLE
Root data directory

### DIFF
--- a/MobileLibrary/Android/PsiphonTunnel/AndroidManifest.xml
+++ b/MobileLibrary/Android/PsiphonTunnel/AndroidManifest.xml
@@ -1,2 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="ca.psiphon">
-<uses-sdk android:minSdkVersion="15"/></manifest>
+    <uses-sdk android:minSdkVersion="15"/>
+    <application android:fullBackupContent="@xml/ca_psiphon_psiphontunnel_backup_rules"/>
+</manifest>

--- a/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
+++ b/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
@@ -135,6 +135,23 @@ public class PsiphonTunnel {
         return mPsiphonTunnel;
     }
 
+    // Returns default path where upgrade downloads will be paved. Only applicable if
+    // DataRootDirectory was not set in the outer config. If DataRootDirectory was set in the
+    // outer config, use getUpgradeDownloadFilePath with its value instead.
+    public static String getDefaultUpgradeDownloadFilePath(Context context) {
+        return Psi.upgradeDownloadFilePath(defaultDataRootDirectory(context).getAbsolutePath());
+    }
+
+    // Returns the path where upgrade downloads will be paved relative to the configured
+    // DataRootDirectory.
+    public static String getUpgradeDownloadFilePath(String dataRootDirectoryPath) {
+        return Psi.upgradeDownloadFilePath(dataRootDirectoryPath);
+    }
+
+    private static File defaultDataRootDirectory(Context context) {
+        return context.getFileStreamPath("ca.psiphon.PsiphonTunnel.tunnel-core");
+    }
+
     private PsiphonTunnel(HostService hostService, boolean shouldRouteThroughTunnelAutomatically) {
         mHostService = hostService;
         mVpnMode = new AtomicBoolean(false);
@@ -593,7 +610,7 @@ public class PsiphonTunnel {
     }
 
     private String loadPsiphonConfig(Context context)
-            throws IOException, JSONException {
+            throws IOException, JSONException, Exception {
 
         // Load settings from the raw resource JSON config file and
         // update as necessary. Then write JSON to disk for the Go client.
@@ -602,23 +619,31 @@ public class PsiphonTunnel {
         // On Android, this directory must be set to the app private storage area.
         // The Psiphon library won't be able to use its current working directory
         // and the standard temporary directories do not exist.
-        if (!json.has("DataStoreDirectory")) {
-            json.put("DataStoreDirectory", context.getFilesDir());
+        if (!json.has("DataRootDirectory")) {
+            File dataRootDirectory = defaultDataRootDirectory(context);
+            if (!dataRootDirectory.exists()) {
+                boolean created = dataRootDirectory.mkdir();
+                if (!created) {
+                    throw new Exception("failed to create data root directory: " + dataRootDirectory.getPath());
+                }
+            }
+            json.put("DataRootDirectory", defaultDataRootDirectory(context));
         }
 
+        // Migrate datastore files from legacy directory.
+        if (!json.has("DataStoreDirectory")) {
+            json.put("MigrateDataStoreDirectory", context.getFilesDir());
+        }
+
+        // Migrate remote server list downloads from legacy location.
         if (!json.has("RemoteServerListDownloadFilename")) {
             File remoteServerListDownload = new File(context.getFilesDir(), "remote_server_list");
-            json.put("RemoteServerListDownloadFilename", remoteServerListDownload.getAbsolutePath());
+            json.put("MigrateRemoteServerListDownloadFilename", remoteServerListDownload.getAbsolutePath());
         }
 
+        // Migrate obfuscated server list download files from legacy directory.
         File oslDownloadDir = new File(context.getFilesDir(), "osl");
-        if (!oslDownloadDir.exists()
-                && !oslDownloadDir.mkdirs()) {
-            // Failed to create osl directory
-            // TODO: proceed anyway?
-            throw new IOException("failed to create OSL download directory");
-        }
-        json.put("ObfuscatedServerListDownloadDirectory", oslDownloadDir.getAbsolutePath());
+        json.put("MigrateObfuscatedServerListDownloadDirectory", oslDownloadDir.getAbsolutePath());
 
         // Note: onConnecting/onConnected logic assumes 1 tunnel connection
         json.put("TunnelPoolSize", 1);

--- a/MobileLibrary/Android/PsiphonTunnel/ca_psiphon_psiphontunnel_backup_rules.xml
+++ b/MobileLibrary/Android/PsiphonTunnel/ca_psiphon_psiphontunnel_backup_rules.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <include domain="file" path="ca.psiphon.PsiphonTunnel.tunnel-core" />
+</full-backup-content>

--- a/MobileLibrary/Android/make.bash
+++ b/MobileLibrary/Android/make.bash
@@ -75,6 +75,8 @@ yes | cp -f PsiphonTunnel/libs/armeabi-v7a/libtun2socks.so build-tmp/psi/jni/arm
 yes | cp -f PsiphonTunnel/libs/arm64-v8a/libtun2socks.so build-tmp/psi/jni/arm64-v8a/libtun2socks.so
 yes | cp -f PsiphonTunnel/libs/x86/libtun2socks.so build-tmp/psi/jni/x86/libtun2socks.so
 yes | cp -f PsiphonTunnel/libs/x86_64/libtun2socks.so build-tmp/psi/jni/x86_64/libtun2socks.so
+mkdir -p build-tmp/psi/res/xml
+yes | cp -f PsiphonTunnel/ca_psiphon_psiphontunnel_backup_rules.xml build-tmp/psi/res/xml/ca_psiphon_psiphontunnel_backup_rules.xml
 
 javac -d build-tmp -bootclasspath $ANDROID_HOME/platforms/android-23/android.jar -source 1.8 -target 1.8 -classpath build-tmp/psi/classes.jar PsiphonTunnel/PsiphonTunnel.java
 if [ $? != 0 ]; then

--- a/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel.xcodeproj/project.pbxproj
+++ b/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel.xcodeproj/project.pbxproj
@@ -40,6 +40,8 @@
 		66BDB0661DC26CCC0079384C /* SBJson4StreamWriterState.m in Sources */ = {isa = PBXBuildFile; fileRef = 66BDB0571DC26CCC0079384C /* SBJson4StreamWriterState.m */; };
 		66BDB0671DC26CCC0079384C /* SBJson4Writer.h in Headers */ = {isa = PBXBuildFile; fileRef = 66BDB0581DC26CCC0079384C /* SBJson4Writer.h */; };
 		66BDB0681DC26CCC0079384C /* SBJson4Writer.m in Sources */ = {isa = PBXBuildFile; fileRef = 66BDB0591DC26CCC0079384C /* SBJson4Writer.m */; };
+		CE3D1DA523906003009A4AF6 /* Backups.h in Headers */ = {isa = PBXBuildFile; fileRef = CE3D1DA323906003009A4AF6 /* Backups.h */; };
+		CE3D1DA623906003009A4AF6 /* Backups.m in Sources */ = {isa = PBXBuildFile; fileRef = CE3D1DA423906003009A4AF6 /* Backups.m */; };
 		EFED7EBF1F587F6E0078980F /* libresolv.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = EFED7EBE1F587F6E0078980F /* libresolv.tbd */; };
 /* End PBXBuildFile section */
 
@@ -102,6 +104,8 @@
 		66BDB0571DC26CCC0079384C /* SBJson4StreamWriterState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SBJson4StreamWriterState.m; sourceTree = "<group>"; };
 		66BDB0581DC26CCC0079384C /* SBJson4Writer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SBJson4Writer.h; sourceTree = "<group>"; };
 		66BDB0591DC26CCC0079384C /* SBJson4Writer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SBJson4Writer.m; sourceTree = "<group>"; };
+		CE3D1DA323906003009A4AF6 /* Backups.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Backups.h; sourceTree = "<group>"; };
+		CE3D1DA423906003009A4AF6 /* Backups.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Backups.m; sourceTree = "<group>"; };
 		EFED7EBE1F587F6E0078980F /* libresolv.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libresolv.tbd; path = usr/lib/libresolv.tbd; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -183,9 +187,10 @@
 		66BDB0221DA6BFCC0079384C /* PsiphonTunnel */ = {
 			isa = PBXGroup;
 			children = (
+				CE3D1D9E239056E4009A4AF6 /* Files */,
 				66BAD3321E525FBC00CD06DE /* JailbreakCheck */,
-				662659241DD270E900872F6C /* Reachability */,
 				66BDB04A1DC26CCC0079384C /* json-framework */,
+				662659241DD270E900872F6C /* Reachability */,
 				66BDB0231DA6BFCC0079384C /* PsiphonTunnel.h */,
 				66BDB0431DA6C7DD0079384C /* PsiphonTunnel.m */,
 				66BDB0241DA6BFCC0079384C /* Info.plist */,
@@ -233,6 +238,15 @@
 			path = "json-framework";
 			sourceTree = "<group>";
 		};
+		CE3D1D9E239056E4009A4AF6 /* Files */ = {
+			isa = PBXGroup;
+			children = (
+				CE3D1DA323906003009A4AF6 /* Backups.h */,
+				CE3D1DA423906003009A4AF6 /* Backups.m */,
+			);
+			path = Files;
+			sourceTree = "<group>";
+		};
 		EFED7EBD1F587F6E0078980F /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -248,6 +262,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CE3D1DA523906003009A4AF6 /* Backups.h in Headers */,
 				6685BDCB1E2E882800F0E414 /* ref.h in Headers */,
 				66BAD3351E525FBC00CD06DE /* JailbreakCheck.h in Headers */,
 				4E89F7FF1E2ED3CE00005F4C /* LookupIPv6.h in Headers */,
@@ -335,6 +350,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 66BDB0161DA6BFCC0079384C;
@@ -399,6 +415,7 @@
 				66BDB0441DA6C7DD0079384C /* PsiphonTunnel.m in Sources */,
 				662659281DD270E900872F6C /* Reachability.m in Sources */,
 				66BDB0601DC26CCC0079384C /* SBJson4StreamParserState.m in Sources */,
+				CE3D1DA623906003009A4AF6 /* Backups.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel.xcodeproj/xcshareddata/xcschemes/PsiphonTunnel.xcscheme
+++ b/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel.xcodeproj/xcshareddata/xcschemes/PsiphonTunnel.xcscheme
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "66BDB01F1DA6BFCC0079384C"
+            BuildableName = "PsiphonTunnel.framework"
+            BlueprintName = "PsiphonTunnel"
+            ReferencedContainer = "container:PsiphonTunnel.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "66BDB01F1DA6BFCC0079384C"
-            BuildableName = "PsiphonTunnel.framework"
-            BlueprintName = "PsiphonTunnel"
-            ReferencedContainer = "container:PsiphonTunnel.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -70,8 +68,6 @@
             ReferencedContainer = "container:PsiphonTunnel.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel/Files/Backups.h
+++ b/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel/Files/Backups.h
@@ -1,0 +1,34 @@
+/*
+* Copyright (c) 2019, Psiphon Inc.
+* All rights reserved.
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+*/
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface Backups : NSObject
+
+/// Excludes the target file from application backups made by iCloud and iTunes.
+/// If NO is returned, the file was not successfully excluded from backup and the error is populated.
+/// @param filePath Path at which the file exists.
+/// @param err If non-nil, contains the error encountered when attempting to exclude the file from backup.
++ (BOOL)excludeFileFromBackup:(NSString*)filePath err:(NSError**)err;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel/Files/Backups.m
+++ b/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel/Files/Backups.m
@@ -1,0 +1,38 @@
+/*
+* Copyright (c) 2019, Psiphon Inc.
+* All rights reserved.
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+*/
+
+#import "Backups.h"
+
+@implementation Backups
+
+// See comment in header
++ (BOOL)excludeFileFromBackup:(NSString*)filePath err:(NSError**)err {
+    *err = nil;
+
+    // The URL must be of the file scheme ("file://"), otherwise the `setResourceValue:forKey:error`
+    // operation will silently fail with: "CFURLCopyResourcePropertyForKey failed because passed URL
+    // no scheme".
+    NSURL *urlWithScheme = [NSURL fileURLWithPath:filePath];
+
+    return [urlWithScheme setResourceValue:[NSNumber numberWithBool:YES]
+                                    forKey:NSURLIsExcludedFromBackupKey
+                                     error:err];
+}
+
+@end

--- a/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel/PsiphonTunnel.h
+++ b/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel/PsiphonTunnel.h
@@ -140,18 +140,6 @@ typedef NS_ENUM(NSInteger, PsiphonConnectionState)
 - (NSString * _Nullable)getEmbeddedServerEntriesPath;
 
 /*!
-  Called when the tunnel is starting. If this method is implemented, it should return the path where a homepage
-  notices file is to be written. This path should be writable by the library.
- */
-- (NSString * _Nullable)getHomepageNoticesPath;
-
-/*!
-  Called when the tunnel is starting. If this method is implemented, it should return the path where a rotating
-  notice file set is to be written. path file should be writable by the library.
- */
-- (NSString * _Nullable)getRotatingNoticesPath;
-
-/*!
  Gets runtime errors info that may be useful for debugging.
  @param message  The diagnostic message string.
  @param timestamp RFC3339 encoded timestamp.
@@ -324,13 +312,47 @@ Swift: @code func onInternetReachabilityChanged(_ currentReachability: Reachabil
 + (PsiphonTunnel * _Nonnull)newPsiphonTunnel:(id<TunneledAppDelegate> _Nonnull)tunneledAppDelegate;
 
 /*!
+Returns the default data root directory that is used by PsiphonTunnel if DataRootDirectory is not specified in the config returned by
+getPsiphonConfig.
+@param err Any error encountered while obtaining the default data root directory. If set, the return value should be ignored.
+@return  The default data root directory used by PsiphonTunnel.
+*/
++ (NSURL * _Nullable)defaultDataRootDirectoryWithError:(NSError * _Nullable * _Nonnull)err;
+
+/*!
+Returns the path where the homepage notices file will be created.
+@note    This file will only be created if UseNoticeFiles is set in the config returned by `getPsiphonConfig`.
+@param dataRootDirectory the configured data root directory. If DataRootDirectory is not specified in the config returned by
+getPsiphonConfig, then use `defaultDataRootDirectory`.
+@return  The file path at which the homepage file will be created.
+*/
++ (NSURL * _Nullable)homepageFilePath:(NSURL * _Nonnull)dataRootDirectory;
+
+/*!
+Returns the path where the notices file will be created. When the file is rotated it will be moved to `oldNoticesFilePath`.
+@note    This file will only be created if UseNoticeFiles is set in the config returned by `getPsiphonConfig`.
+@param dataRootDirectory the configured data root directory. If DataRootDirectory is not specified in the config returned by
+`getPsiphonConfig`, then use `defaultDataRootDirectory`.
+@return  The file path at which the notices file will be created.
+*/
++ (NSURL * _Nullable)noticesFilePath:(NSURL * _Nonnull)dataRootDirectory;
+
+/*!
+Returns the path where the rotated notices file will be created.
+@note    This file will only be created if UseNoticeFiles is set in the config returned by `getPsiphonConfig`.
+@param dataRootDirectory the configured data root directory. If DataRootDirectory is not specified in the config returned by
+`getPsiphonConfig`, then use `defaultDataRootDirectory`.
+@return  The file path at which the rotated notices file can be found once rotated.
+*/
++ (NSURL * _Nullable)olderNoticesFilePath:(NSURL * _Nonnull)dataRootDirectory;
+
+/*!
  Start connecting the PsiphonTunnel. Returns before connection is complete -- delegate callbacks (such as `onConnected` and `onConnectionStateChanged`) are used to indicate progress and state.
  @param ifNeeded  If TRUE, the tunnel will only be started if it's not already connected and healthy. If FALSE, the tunnel will be forced to stop and reconnect.
  @return TRUE if the connection start was successful, FALSE otherwise.
  Swift: @code func start(_ ifNeeded: Bool) -> Bool @endcode
  */
 - (BOOL)start:(BOOL)ifNeeded;
-
 
 /*!
  Reconnect a previously started PsiphonTunnel with the specified config changes.

--- a/MobileLibrary/psi/psi.go
+++ b/MobileLibrary/psi/psi.go
@@ -29,6 +29,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -49,21 +50,44 @@ type PsiphonProvider interface {
 	GetNetworkID() string
 }
 
-func SetNoticeFiles(
-	homepageFilename,
-	rotatingFilename string,
-	rotatingFileSize,
-	rotatingSyncFrequency int) error {
-
-	return psiphon.SetNoticeFiles(
-		homepageFilename,
-		rotatingFilename,
-		rotatingFileSize,
-		rotatingSyncFrequency)
-}
-
 func NoticeUserLog(message string) {
 	psiphon.NoticeUserLog(message)
+}
+
+// HomepageFilePath returns the path, relative to the configured data root
+// directory, where homepage files will be paved.
+//
+// Note: homepage files will only be paved if UseNoticeFiles is set in the
+// config passed to Start().
+func HomepageFilePath(rootDataDirectoryPath string) string {
+	return filepath.Join(rootDataDirectoryPath, psiphon.HomepageFilename)
+}
+
+// NoticesFilePath returns the path, relative to the configured data root
+// directory, where the notices file will be paved.
+//
+// Note: notices will only be paved if UseNoticeFiles is set in the config
+// passed to Start().
+func NoticesFilePath(rootDataDirectoryPath string) string {
+	return filepath.Join(rootDataDirectoryPath, psiphon.NoticesFilename)
+}
+
+// OldNoticesFilePath returns the path, relative to the configured data root
+// directory, where the notices file is moved to when file rotation occurs.
+//
+// Note: notices will only be paved if UseNoticeFiles is set in the config
+// passed to Start().
+func OldNoticesFilePath(rootDataDirectoryPath string) string {
+	return filepath.Join(rootDataDirectoryPath, psiphon.OldNoticesFilename)
+}
+
+// UpgradeDownloadFilePath returns the path, relative to the configured data
+// root directory, where the downloaded upgrade file will be paved.
+//
+// Note: upgrades will only be paved if UpgradeDownloadURLs is set in the config
+// passed to Start() and there are upgrades available.
+func UpgradeDownloadFilePath(rootDataDirectoryPath string) string {
+	return filepath.Join(rootDataDirectoryPath, psiphon.UpgradeDownloadFilename)
 }
 
 var controllerMutex sync.Mutex

--- a/MobileLibrary/psi/psi.go
+++ b/MobileLibrary/psi/psi.go
@@ -54,40 +54,46 @@ func NoticeUserLog(message string) {
 	psiphon.NoticeUserLog(message)
 }
 
-// HomepageFilePath returns the path, relative to the configured data root
-// directory, where homepage files will be paved.
+// HomepageFilePath returns the path where homepage files will be paved.
+//
+// rootDataDirectoryPath is the configured data root directory.
 //
 // Note: homepage files will only be paved if UseNoticeFiles is set in the
 // config passed to Start().
 func HomepageFilePath(rootDataDirectoryPath string) string {
-	return filepath.Join(rootDataDirectoryPath, psiphon.HomepageFilename)
+	return filepath.Join(rootDataDirectoryPath, psiphon.PsiphonDataDirectoryName, psiphon.HomepageFilename)
 }
 
-// NoticesFilePath returns the path, relative to the configured data root
-// directory, where the notices file will be paved.
+// NoticesFilePath returns the path where the notices file will be paved.
+//
+// rootDataDirectoryPath is the configured data root directory.
 //
 // Note: notices will only be paved if UseNoticeFiles is set in the config
 // passed to Start().
 func NoticesFilePath(rootDataDirectoryPath string) string {
-	return filepath.Join(rootDataDirectoryPath, psiphon.NoticesFilename)
+	return filepath.Join(rootDataDirectoryPath, psiphon.PsiphonDataDirectoryName, psiphon.NoticesFilename)
 }
 
-// OldNoticesFilePath returns the path, relative to the configured data root
-// directory, where the notices file is moved to when file rotation occurs.
+// OldNoticesFilePath returns the path where the notices file is moved to when
+// file rotation occurs.
+//
+// rootDataDirectoryPath is the configured data root directory.
 //
 // Note: notices will only be paved if UseNoticeFiles is set in the config
 // passed to Start().
 func OldNoticesFilePath(rootDataDirectoryPath string) string {
-	return filepath.Join(rootDataDirectoryPath, psiphon.OldNoticesFilename)
+	return filepath.Join(rootDataDirectoryPath, psiphon.PsiphonDataDirectoryName, psiphon.OldNoticesFilename)
 }
 
-// UpgradeDownloadFilePath returns the path, relative to the configured data
-// root directory, where the downloaded upgrade file will be paved.
+// UpgradeDownloadFilePath returns the path where the downloaded upgrade file
+// will be paved.
+//
+// rootDataDirectoryPath is the configured data root directory.
 //
 // Note: upgrades will only be paved if UpgradeDownloadURLs is set in the config
 // passed to Start() and there are upgrades available.
 func UpgradeDownloadFilePath(rootDataDirectoryPath string) string {
-	return filepath.Join(rootDataDirectoryPath, psiphon.UpgradeDownloadFilename)
+	return filepath.Join(rootDataDirectoryPath, psiphon.PsiphonDataDirectoryName, psiphon.UpgradeDownloadFilename)
 }
 
 var controllerMutex sync.Mutex

--- a/psiphon/common/utils.go
+++ b/psiphon/common/utils.go
@@ -27,6 +27,7 @@ import (
 	"io"
 	"io/ioutil"
 	"math"
+	"os"
 	"time"
 
 	"github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/errors"
@@ -177,4 +178,59 @@ func CopyNBuffer(dst io.Writer, src io.Reader, n int64, buf []byte) (written int
 		err = io.EOF
 	}
 	return
+}
+
+// FileExists returns true if a file, or directory, exists at the given path.
+func FileExists(filePath string) bool {
+	if _, err := os.Stat(filePath); err != nil && os.IsNotExist(err) {
+		return false
+	}
+	return true
+}
+
+// FileMigration represents the action of moving a file, or directory, to a new
+// location.
+type FileMigration struct {
+
+	// OldPath is the current location of the file.
+	OldPath string
+
+	// NewPath is the location that the file should be moved to.
+	NewPath string
+
+	// IsDir should be set to true if the file is a directory.
+	IsDir bool
+}
+
+// DoFileMigration performs the specified file move operation. An error will be
+// returned and the operation will not performed if: a file is expected, but a
+// directory is found; a directory is expected, but a file is found; or a file,
+// or directory, already exists at the target path of the move operation.
+func DoFileMigration(migration FileMigration) error {
+	if !FileExists(migration.OldPath) {
+		return errors.Tracef("%s does not exist", migration.OldPath)
+	}
+	info, err := os.Stat(migration.OldPath)
+	if err != nil {
+		return errors.Tracef("error getting file info of %s: %s", migration.OldPath, err.Error())
+	}
+	if info.IsDir() != migration.IsDir {
+		if migration.IsDir {
+			return errors.Tracef("expected directory %s to be directory but found file", migration.OldPath)
+		}
+
+		return errors.Tracef("expected %s to be file but found directory",
+			migration.OldPath)
+	}
+
+	if FileExists(migration.NewPath) {
+		return errors.Tracef("%s already exists, will not overwrite", migration.NewPath)
+	}
+
+	err = os.Rename(migration.OldPath, migration.NewPath)
+	if err != nil {
+		return errors.Tracef("renaming %s as %s failed with error %s", migration.OldPath, migration.NewPath, err.Error())
+	}
+
+	return nil
 }

--- a/psiphon/config.go
+++ b/psiphon/config.go
@@ -904,7 +904,7 @@ func (config *Config) Commit() error {
 	// Validate config fields.
 
 	if !common.FileExists(config.DataRootDirectory) {
-		return errors.Tracef("DataRootDirectory does not exist: %s", config.MigrateDataStoreDirectory)
+		return errors.Tracef("DataRootDirectory does not exist: %s", config.DataRootDirectory)
 	}
 
 	if config.PropagationChannelId == "" {

--- a/psiphon/config.go
+++ b/psiphon/config.go
@@ -1123,7 +1123,12 @@ func (config *Config) Commit() error {
 
 			oldUpgradeDownloadFilename := filepath.Base(config.MigrateUpgradeDownloadFilename)
 
-			upgradeDownloadFileRegex, err := regexp.Compile(`^` + oldUpgradeDownloadFilename + `(\.part.*)*$`)
+			// Create regex for:
+			// <old_upgrade_download_filename>
+			// <old_upgrade_download_filename>.<client_version_number>
+			// <old_upgrade_download_filename>.<client_version_number>.part
+			// <old_upgrade_download_filename>.<client_version_number>.part.etag
+			upgradeDownloadFileRegex, err := regexp.Compile(`^` + oldUpgradeDownloadFilename + `(\.\d+(\.part(\.etag)?)?)?$`)
 			if err != nil {
 				return errors.TraceMsg(err, "failed to compile regex for upgrade files")
 			}

--- a/psiphon/config.go
+++ b/psiphon/config.go
@@ -92,8 +92,6 @@ type Config struct {
 	// See comment for setNoticeFiles in notice.go for further details.
 	UseNoticeFiles *UseNoticeFiles
 
-
-
 	// PropagationChannelId is a string identifier which indicates how the
 	// Psiphon client was distributed. This parameter is required. This value
 	// is supplied by and depends on the Psiphon Network, and is typically
@@ -821,6 +819,15 @@ func (config *Config) Commit() error {
 		}
 	}
 
+	// Create tapdance directory
+	tapdanceDirectoryPath := config.GetTapdanceDirectory()
+	if !common.FileExists(tapdanceDirectoryPath) {
+		err := os.Mkdir(tapdanceDirectoryPath, os.ModePerm)
+		if err != nil {
+			return errors.Tracef("failed to create tapdance directory %s with error: %s", tapdanceDirectoryPath, err.Error())
+		}
+	}
+
 	if config.ClientVersion == "" {
 		config.ClientVersion = "0"
 	}
@@ -1065,7 +1072,7 @@ func (config *Config) Commit() error {
 			},
 			{
 				OldPath: filepath.Join(config.MigrateDataStoreDirectory, "tapdance"),
-				NewPath: filepath.Join(config.DataRootDirectory, "tapdance"),
+				NewPath: filepath.Join(config.GetTapdanceDirectory(), "tapdance"),
 				IsDir:   true,
 			},
 		}
@@ -1307,7 +1314,7 @@ func (config *Config) GetUpgradeDownloadFilename() string {
 // GetTapdanceDirectory returns the directory under which tapdance will create
 // and manage files.
 func (config *Config) GetTapdanceDirectory() string {
-	return config.DataRootDirectory
+	return filepath.Join(config.DataRootDirectory, "tapdance")
 }
 
 // UseUpstreamProxy indicates if an upstream proxy has been

--- a/psiphon/config.go
+++ b/psiphon/config.go
@@ -92,104 +92,7 @@ type Config struct {
 	// See comment for setNoticeFiles in notice.go for further details.
 	UseNoticeFiles *UseNoticeFiles
 
-	// MigrateHompageNoticesFilename migrates a homepage file from the path
-	// previously configured with setNoticeFiles to the new path for homepage
-	// files under the data root directory. The file specified by this config
-	// value will be moved to config.GetHomePageFilename().
-	//
-	// If not set, no migration operation will be performed.
-	MigrateHompageNoticesFilename string
 
-	// MigrateRotatingNoticesFilename migrates notice files from the path
-	// previously configured with setNoticeFiles to the new path for notice
-	// files under the data root directory.
-	//
-	// MigrateRotatingNoticesFilename will be moved to
-	// config.GetNoticesFilename().
-	//
-	// MigrateRotatingNoticesFilename.1 will be moved to
-	// config.GetOldNoticesFilename().
-	//
-	// If not set, no migration operation will be performed.
-	MigrateRotatingNoticesFilename string
-
-	// DataStoreDirectory is the directory in which to store the persistent
-	// database, which contains information such as server entries. By
-	// default, current working directory.
-	//
-	// Deprecated:
-	// Use MigrateDataStoreDirectory. When MigrateDataStoreDirectory
-	// is set, this parameter is ignored.
-	//
-	// DataStoreDirectory has been subsumed by the new data root directory,
-	// which is configured with DataRootDirectory. If set, datastore files
-	// found in the specified directory will be moved under the data root
-	// directory.
-	DataStoreDirectory string
-
-	// MigrateDataStoreDirectory indicates the location of the datastore
-	// directory, as previously configured with the deprecated
-	// DataStoreDirectory config field. Datastore files found in the specified
-	// directory will be moved under the data root directory.
-	MigrateDataStoreDirectory string
-
-	// RemoteServerListDownloadFilename specifies a target filename for
-	// storing the remote server list download. Data is stored in co-located
-	// files (RemoteServerListDownloadFilename.part*) to allow for resumable
-	// downloading.
-	//
-	// Deprecated:
-	// Use MigrateRemoteServerListDownloadFilename. When
-	// MigrateRemoteServerListDownloadFilename is set, this parameter is
-	// ignored.
-	//
-	// If set, remote server list download files found at the specified path
-	// will be moved under the data root directory.
-	RemoteServerListDownloadFilename string
-
-	// MigrateRemoteServerListDownloadFilename indicates the location of
-	// remote server list download files. The remote server list files found at
-	// the specified path will be moved under the data root directory.
-	MigrateRemoteServerListDownloadFilename string
-
-	// ObfuscatedServerListDownloadDirectory specifies a target directory for
-	// storing the obfuscated remote server list downloads. Data is stored in
-	// co-located files (<OSL filename>.part*) to allow for resumable
-	// downloading.
-	//
-	// Deprecated:
-	// Use MigrateObfuscatedServerListDownloadDirectory. When
-	// MigrateObfuscatedServerListDownloadDirectory is set, this parameter is
-	// ignored.
-	//
-	// If set, obfuscated server list download files found at the specified path
-	// will be moved under the data root directory.
-	ObfuscatedServerListDownloadDirectory string
-
-	// MigrateObfuscatedServerListDownloadDirectory indicates the location of
-	// the obfuscated server list downloads directory, as previously configured
-	// with ObfuscatedServerListDownloadDirectory. Obfuscated server list
-	// download files found in the specified directory will be moved under the
-	// data root directory.
-	MigrateObfuscatedServerListDownloadDirectory string
-
-	// UpgradeDownloadFilename is the local target filename for an upgrade
-	// download. This parameter is required when UpgradeDownloadURLs (or
-	// UpgradeDownloadUrl) is specified. Data is stored in co-located files
-	// (UpgradeDownloadFilename.part*) to allow for resumable downloading.
-	//
-	// Deprecated:
-	// Use MigrateUpgradeDownloadFilename. When MigrateUpgradeDownloadFilename
-	// is set, this parameter is ignored.
-	//
-	// If set, upgrade download files found at the specified path will be moved
-	// under the data root directory.
-	UpgradeDownloadFilename string
-
-	// MigrateUpgradeDownloadFilename indicates the location of downloaded
-	// application upgrade files. Downloaded upgrade files found at the
-	// specified path will be moved under the data root directory.
-	MigrateUpgradeDownloadFilename string
 
 	// PropagationChannelId is a string identifier which indicates how the
 	// Psiphon client was distributed. This parameter is required. This value
@@ -256,13 +159,6 @@ type Config struct {
 	// slow networks.
 	// When set, must be >= 1.0.
 	NetworkLatencyMultiplier float64
-
-	// TunnelProtocol indicates which protocol to use. For the default, "",
-	// all protocols are used.
-	//
-	// Deprecated: Use LimitTunnelProtocols. When LimitTunnelProtocols is not
-	// nil, this parameter is ignored.
-	TunnelProtocol string
 
 	// LimitTunnelProtocols indicates which protocols to use. Valid values
 	// include:
@@ -354,10 +250,6 @@ type Config struct {
 	// upstream proxy when specified by UpstreamProxyURL.
 	CustomHeaders http.Header
 
-	// Deprecated: Use CustomHeaders. When CustomHeaders is not nil, this
-	// parameter is ignored.
-	UpstreamProxyCustomHeaders http.Header
-
 	// NetworkConnectivityChecker is an interface that enables tunnel-core to
 	// call into the host application to check for network connectivity. See:
 	// NetworkConnectivityChecker doc.
@@ -427,15 +319,6 @@ type Config struct {
 	// speed test samples.
 	TargetApiProtocol string
 
-	// RemoteServerListUrl is a URL which specifies a location to fetch out-
-	// of-band server entries. This facility is used when a tunnel cannot be
-	// established to known servers. This value is supplied by and depends on
-	// the Psiphon Network, and is typically embedded in the client binary.
-	//
-	// Deprecated: Use RemoteServerListURLs. When RemoteServerListURLs is not
-	// nil, this parameter is ignored.
-	RemoteServerListUrl string
-
 	// RemoteServerListURLs is list of URLs which specify locations to fetch
 	// out-of-band server entries. This facility is used when a tunnel cannot
 	// be established to known servers. This value is supplied by and depends
@@ -458,15 +341,6 @@ type Config struct {
 	// resuming a remote server list download after a failure. If omitted, a
 	// default value is used. This value is typical overridden for testing.
 	FetchRemoteServerListRetryPeriodMilliseconds *int
-
-	// ObfuscatedServerListRootURL is a URL which specifies the root location
-	// from which to fetch obfuscated server list files. This value is
-	// supplied by and depends on the Psiphon Network, and is typically
-	// embedded in the client binary.
-	//
-	// Deprecated: Use ObfuscatedServerListRootURLs. When
-	// ObfuscatedServerListRootURLs is not nil, this parameter is ignored.
-	ObfuscatedServerListRootURL string
 
 	// ObfuscatedServerListRootURLs is a list of URLs which specify root
 	// locations from which to fetch obfuscated server list files. This value
@@ -496,16 +370,6 @@ type Config struct {
 	// forward target domain names to IP addresses for classification. The DNS
 	// server must support TCP requests.
 	SplitTunnelDNSServer string
-
-	// UpgradeDownloadUrl specifies a URL from which to download a host client
-	// upgrade file, when one is available. The core tunnel controller
-	// provides a resumable download facility which downloads this resource
-	// and emits a notice when complete. This value is supplied by and depends
-	// on the Psiphon Network, and is typically embedded in the client binary.
-	//
-	// Deprecated: Use UpgradeDownloadURLs. When UpgradeDownloadURLs is not
-	// nil, this parameter is ignored.
-	UpgradeDownloadUrl string
 
 	// UpgradeDownloadURLs is list of URLs which specify locations from which
 	// to download a host client upgrade file, when one is available. The core
@@ -678,6 +542,144 @@ type Config struct {
 
 	// ApplicationParameters is for testing purposes.
 	ApplicationParameters parameters.KeyValues
+
+	// MigrateHompageNoticesFilename migrates a homepage file from the path
+	// previously configured with setNoticeFiles to the new path for homepage
+	// files under the data root directory. The file specified by this config
+	// value will be moved to config.GetHomePageFilename().
+	//
+	// If not set, no migration operation will be performed.
+	MigrateHompageNoticesFilename string
+
+	// MigrateRotatingNoticesFilename migrates notice files from the path
+	// previously configured with setNoticeFiles to the new path for notice
+	// files under the data root directory.
+	//
+	// MigrateRotatingNoticesFilename will be moved to
+	// config.GetNoticesFilename().
+	//
+	// MigrateRotatingNoticesFilename.1 will be moved to
+	// config.GetOldNoticesFilename().
+	//
+	// If not set, no migration operation will be performed.
+	MigrateRotatingNoticesFilename string
+
+	// DataStoreDirectory is the directory in which to store the persistent
+	// database, which contains information such as server entries. By
+	// default, current working directory.
+	//
+	// Deprecated:
+	// Use MigrateDataStoreDirectory. When MigrateDataStoreDirectory
+	// is set, this parameter is ignored.
+	//
+	// DataStoreDirectory has been subsumed by the new data root directory,
+	// which is configured with DataRootDirectory. If set, datastore files
+	// found in the specified directory will be moved under the data root
+	// directory.
+	DataStoreDirectory string
+
+	// MigrateDataStoreDirectory indicates the location of the datastore
+	// directory, as previously configured with the deprecated
+	// DataStoreDirectory config field. Datastore files found in the specified
+	// directory will be moved under the data root directory.
+	MigrateDataStoreDirectory string
+
+	// RemoteServerListDownloadFilename specifies a target filename for
+	// storing the remote server list download. Data is stored in co-located
+	// files (RemoteServerListDownloadFilename.part*) to allow for resumable
+	// downloading.
+	//
+	// Deprecated:
+	// Use MigrateRemoteServerListDownloadFilename. When
+	// MigrateRemoteServerListDownloadFilename is set, this parameter is
+	// ignored.
+	//
+	// If set, remote server list download files found at the specified path
+	// will be moved under the data root directory.
+	RemoteServerListDownloadFilename string
+
+	// MigrateRemoteServerListDownloadFilename indicates the location of
+	// remote server list download files. The remote server list files found at
+	// the specified path will be moved under the data root directory.
+	MigrateRemoteServerListDownloadFilename string
+
+	// ObfuscatedServerListDownloadDirectory specifies a target directory for
+	// storing the obfuscated remote server list downloads. Data is stored in
+	// co-located files (<OSL filename>.part*) to allow for resumable
+	// downloading.
+	//
+	// Deprecated:
+	// Use MigrateObfuscatedServerListDownloadDirectory. When
+	// MigrateObfuscatedServerListDownloadDirectory is set, this parameter is
+	// ignored.
+	//
+	// If set, obfuscated server list download files found at the specified path
+	// will be moved under the data root directory.
+	ObfuscatedServerListDownloadDirectory string
+
+	// MigrateObfuscatedServerListDownloadDirectory indicates the location of
+	// the obfuscated server list downloads directory, as previously configured
+	// with ObfuscatedServerListDownloadDirectory. Obfuscated server list
+	// download files found in the specified directory will be moved under the
+	// data root directory.
+	MigrateObfuscatedServerListDownloadDirectory string
+
+	// UpgradeDownloadFilename is the local target filename for an upgrade
+	// download. This parameter is required when UpgradeDownloadURLs (or
+	// UpgradeDownloadUrl) is specified. Data is stored in co-located files
+	// (UpgradeDownloadFilename.part*) to allow for resumable downloading.
+	//
+	// Deprecated:
+	// Use MigrateUpgradeDownloadFilename. When MigrateUpgradeDownloadFilename
+	// is set, this parameter is ignored.
+	//
+	// If set, upgrade download files found at the specified path will be moved
+	// under the data root directory.
+	UpgradeDownloadFilename string
+
+	// MigrateUpgradeDownloadFilename indicates the location of downloaded
+	// application upgrade files. Downloaded upgrade files found at the
+	// specified path will be moved under the data root directory.
+	MigrateUpgradeDownloadFilename string
+
+	// TunnelProtocol indicates which protocol to use. For the default, "",
+	// all protocols are used.
+	//
+	// Deprecated: Use LimitTunnelProtocols. When LimitTunnelProtocols is not
+	// nil, this parameter is ignored.
+	TunnelProtocol string
+
+	// Deprecated: Use CustomHeaders. When CustomHeaders is not nil, this
+	// parameter is ignored.
+	UpstreamProxyCustomHeaders http.Header
+
+	// RemoteServerListUrl is a URL which specifies a location to fetch out-
+	// of-band server entries. This facility is used when a tunnel cannot be
+	// established to known servers. This value is supplied by and depends on
+	// the Psiphon Network, and is typically embedded in the client binary.
+	//
+	// Deprecated: Use RemoteServerListURLs. When RemoteServerListURLs is not
+	// nil, this parameter is ignored.
+	RemoteServerListUrl string
+
+	// ObfuscatedServerListRootURL is a URL which specifies the root location
+	// from which to fetch obfuscated server list files. This value is
+	// supplied by and depends on the Psiphon Network, and is typically
+	// embedded in the client binary.
+	//
+	// Deprecated: Use ObfuscatedServerListRootURLs. When
+	// ObfuscatedServerListRootURLs is not nil, this parameter is ignored.
+	ObfuscatedServerListRootURL string
+
+	// UpgradeDownloadUrl specifies a URL from which to download a host client
+	// upgrade file, when one is available. The core tunnel controller
+	// provides a resumable download facility which downloads this resource
+	// and emits a notice when complete. This value is supplied by and depends
+	// on the Psiphon Network, and is typically embedded in the client binary.
+	//
+	// Deprecated: Use UpgradeDownloadURLs. When UpgradeDownloadURLs is not
+	// nil, this parameter is ignored.
+	UpgradeDownloadUrl string
 
 	// clientParameters is the active ClientParameters with defaults, config
 	// values, and, optionally, tactics applied.

--- a/psiphon/config_test.go
+++ b/psiphon/config_test.go
@@ -292,15 +292,6 @@ func (suite *ConfigTestSuite) Test_LoadConfig_Migrate() {
 				Name: oldRemoteServerListname + ".part.etag",
 			},
 			{
-				Name: oldRemoteServerListname + ".part1",
-			},
-			{
-				Name: oldRemoteServerListname + ".part1.etag",
-			},
-			{
-				Name: oldRemoteServerListname + ".should_not_be_migrated",
-			},
-			{
 				Name: oldObfuscatedServerListDirectoryName,
 				Children: []FileTree{
 					{
@@ -389,7 +380,7 @@ func (suite *ConfigTestSuite) Test_LoadConfig_Migrate() {
 				Name: "data_root_directory",
 				Children: []FileTree{
 					{
-						Name: "psiphon3_migration_complete",
+						Name: "ca.psiphon.PsiphonTunnel.tunnel-core_migration_complete",
 					},
 					{
 						Name: "remote_server_list",
@@ -399,12 +390,6 @@ func (suite *ConfigTestSuite) Test_LoadConfig_Migrate() {
 					},
 					{
 						Name: "remote_server_list.part.etag",
-					},
-					{
-						Name: "remote_server_list.part1",
-					},
-					{
-						Name: "remote_server_list.part1.etag",
 					},
 					{
 						Name: "datastore",
@@ -469,9 +454,6 @@ func (suite *ConfigTestSuite) Test_LoadConfig_Migrate() {
 						Name: "non_tunnel_core_file_should_not_be_migrated",
 					},
 				},
-			},
-			{
-				Name: oldRemoteServerListname + ".should_not_be_migrated",
 			},
 			{
 				Name: oldObfuscatedServerListDirectoryName,

--- a/psiphon/config_test.go
+++ b/psiphon/config_test.go
@@ -432,10 +432,15 @@ func (suite *ConfigTestSuite) Test_LoadConfig_Migrate() {
 						Name: "tapdance",
 						Children: []FileTree{
 							{
-								Name: "file1",
-							},
-							{
-								Name: "file2",
+								Name: "tapdance",
+								Children: []FileTree{
+									{
+										Name: "file1",
+									},
+									{
+										Name: "file2",
+									},
+								},
 							},
 						},
 					},

--- a/psiphon/config_test.go
+++ b/psiphon/config_test.go
@@ -389,84 +389,89 @@ func (suite *ConfigTestSuite) Test_LoadConfig_Migrate() {
 				Name: "data_root_directory",
 				Children: []FileTree{
 					{
-						Name: "ca.psiphon.PsiphonTunnel.tunnel-core_migration_complete",
+						Name: "non_tunnel_core_file_should_not_be_clobbered",
 					},
 					{
-						Name: "remote_server_list",
-					},
-					{
-						Name: "remote_server_list.part",
-					},
-					{
-						Name: "remote_server_list.part.etag",
-					},
-					{
-						Name: "datastore",
+						Name: "ca.psiphon.PsiphonTunnel.tunnel-core",
 						Children: []FileTree{
 							{
-								Name: "psiphon.boltdb",
+								Name: "migration_complete",
 							},
 							{
-								Name: "psiphon.boltdb.lock",
-							},
-						},
-					},
-					{
-						Name: "osl",
-						Children: []FileTree{
-							{
-								Name: "osl-registry",
+								Name: "remote_server_list",
 							},
 							{
-								Name: "osl-registry.cached",
+								Name: "remote_server_list.part",
 							},
 							{
-								Name: "osl-1",
+								Name: "remote_server_list.part.etag",
 							},
 							{
-								Name: "osl-1.part",
+								Name: "datastore",
+								Children: []FileTree{
+									{
+										Name: "psiphon.boltdb",
+									},
+									{
+										Name: "psiphon.boltdb.lock",
+									},
+								},
 							},
-						},
-					},
-					{
-						Name: "tapdance",
-						Children: []FileTree{
+							{
+								Name: "osl",
+								Children: []FileTree{
+									{
+										Name: "osl-registry",
+									},
+									{
+										Name: "osl-registry.cached",
+									},
+									{
+										Name: "osl-1",
+									},
+									{
+										Name: "osl-1.part",
+									},
+								},
+							},
 							{
 								Name: "tapdance",
 								Children: []FileTree{
 									{
-										Name: "file1",
-									},
-									{
-										Name: "file2",
+										Name: "tapdance",
+										Children: []FileTree{
+											{
+												Name: "file1",
+											},
+											{
+												Name: "file2",
+											},
+										},
 									},
 								},
 							},
+							{
+								Name: "upgrade",
+							},
+							{
+								Name: "upgrade.1234",
+							},
+							{
+								Name: "upgrade.1234.part",
+							},
+							{
+								Name: "upgrade.1234.part.etag",
+							},
+							{
+								Name: "notices",
+							},
+							{
+								Name: "notices.1",
+							},
+							{
+								Name: "homepage",
+							},
 						},
-					},
-					{
-						Name: "upgrade",
-					},
-					{
-						Name: "upgrade.1234",
-					},
-					{
-						Name: "upgrade.1234.part",
-					},
-					{
-						Name: "upgrade.1234.part.etag",
-					},
-					{
-						Name: "notices",
-					},
-					{
-						Name: "notices.1",
-					},
-					{
-						Name: "homepage",
-					},
-					{
-						Name: "non_tunnel_core_file_should_not_be_clobbered",
 					},
 				},
 			},

--- a/psiphon/config_test.go
+++ b/psiphon/config_test.go
@@ -321,6 +321,15 @@ func (suite *ConfigTestSuite) Test_LoadConfig_Migrate() {
 				Name: oldUpgradeDownloadFilename,
 			},
 			{
+				Name: oldUpgradeDownloadFilename + ".1234",
+			},
+			{
+				Name: oldUpgradeDownloadFilename + ".1234.part",
+			},
+			{
+				Name: oldUpgradeDownloadFilename + ".1234.part.etag",
+			},
+			{
 				Name: "data_root_directory",
 				Children: []FileTree{
 					{
@@ -432,6 +441,15 @@ func (suite *ConfigTestSuite) Test_LoadConfig_Migrate() {
 					},
 					{
 						Name: "upgrade",
+					},
+					{
+						Name: "upgrade.1234",
+					},
+					{
+						Name: "upgrade.1234.part",
+					},
+					{
+						Name: "upgrade.1234.part.etag",
 					},
 					{
 						Name: "notices",

--- a/psiphon/config_test.go
+++ b/psiphon/config_test.go
@@ -22,9 +22,13 @@ package psiphon
 import (
 	"encoding/json"
 	"io/ioutil"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common"
+	"github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/errors"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -39,6 +43,7 @@ type ConfigTestSuite struct {
 	confStubBlob      []byte
 	requiredFields    []string
 	nonRequiredFields []string
+	testDirectory     string
 }
 
 func (suite *ConfigTestSuite) SetupSuite() {
@@ -52,12 +57,41 @@ func (suite *ConfigTestSuite) SetupSuite() {
 
 	var obj map[string]interface{}
 	json.Unmarshal(suite.confStubBlob, &obj)
+
+	// Use a temporary directory for the data root directory so any artifacts
+	// created by config.Commit() can be cleaned up.
+
+	testDirectory, err := ioutil.TempDir("", "psiphon-config-test")
+	if err != nil {
+		suite.T().Fatalf("TempDir failed: %s\n", err)
+	}
+	suite.testDirectory = testDirectory
+	obj["DataRootDirectory"] = testDirectory
+
+	suite.confStubBlob, err = json.Marshal(obj)
+	if err != nil {
+		suite.T().Fatalf("Marshal failed: %s\n", err)
+	}
+
 	for k, v := range obj {
-		if v == "<placeholder>" {
+		if k == "DataRootDirectory" {
+			// skip
+		} else if v == "<placeholder>" {
 			suite.requiredFields = append(suite.requiredFields, k)
 		} else {
 			suite.nonRequiredFields = append(suite.nonRequiredFields, k)
 		}
+	}
+}
+
+func (suite *ConfigTestSuite) TearDownSuite() {
+	if common.FileExists(suite.testDirectory) {
+		err := os.RemoveAll(suite.testDirectory)
+		if err != nil {
+			suite.T().Fatalf("Failed to remove test directory %s: %s", suite.testDirectory, err.Error())
+		}
+	} else {
+		suite.T().Fatalf("Test directory not found: %s", suite.testDirectory)
 	}
 }
 
@@ -186,4 +220,376 @@ func (suite *ConfigTestSuite) Test_LoadConfig_GoodJson() {
 		err = config.Commit()
 	}
 	suite.Nil(err, "JSON with null for optional values should succeed")
+}
+
+// Test when migrating from old config fields results in filesystem changes.
+func (suite *ConfigTestSuite) Test_LoadConfig_Migrate() {
+
+	// This test needs its own temporary directory because a previous test may
+	// have paved the file which signals that migration has already been
+	// completed.
+	testDirectory, err := ioutil.TempDir("", "psiphon-config-migration-test")
+	if err != nil {
+		suite.T().Fatalf("TempDir failed: %s\n", err)
+	}
+
+	defer func() {
+		if common.FileExists(testDirectory) {
+			err := os.RemoveAll(testDirectory)
+			if err != nil {
+				suite.T().Fatalf("Failed to remove test directory %s: %s", testDirectory, err.Error())
+			}
+		}
+	}()
+
+	// Pre migration files and directories
+	oldDataStoreDirectory := filepath.Join(testDirectory, "datastore_old")
+	oldRemoteServerListname := "rsl"
+	oldObfuscatedServerListDirectoryName := "obfuscated_server_list"
+	oldObfuscatedServerListDirectory := filepath.Join(testDirectory, oldObfuscatedServerListDirectoryName)
+	oldUpgradeDownloadFilename := "upgrade"
+	oldRotatingNoticesFilename := "rotating_notices"
+	oldHomepageNoticeFilename := "homepage"
+
+	// Post migration data root directory
+	testDataRootDirectory := filepath.Join(testDirectory, "data_root_directory")
+
+	oldFileTree := FileTree{
+		Name: testDirectory,
+		Children: []FileTree{
+			{
+				Name: "datastore_old",
+				Children: []FileTree{
+					{
+						Name: "psiphon.boltdb",
+					},
+					{
+						Name: "psiphon.boltdb.lock",
+					},
+					{
+						Name: "tapdance",
+						Children: []FileTree{
+							{
+								Name: "file1",
+							},
+							{
+								Name: "file2",
+							},
+						},
+					},
+					{
+						Name: "non_tunnel_core_file_should_not_be_migrated",
+					},
+				},
+			},
+			{
+				Name: oldRemoteServerListname,
+			},
+			{
+				Name: oldRemoteServerListname + ".part",
+			},
+			{
+				Name: oldRemoteServerListname + ".part.etag",
+			},
+			{
+				Name: oldRemoteServerListname + ".part1",
+			},
+			{
+				Name: oldRemoteServerListname + ".part1.etag",
+			},
+			{
+				Name: oldRemoteServerListname + ".should_not_be_migrated",
+			},
+			{
+				Name: oldObfuscatedServerListDirectoryName,
+				Children: []FileTree{
+					{
+						Name: "osl-registry",
+					},
+					{
+						Name: "osl-registry.cached",
+					},
+					{
+						Name: "osl-1",
+					},
+					{
+						Name: "osl-1.part",
+					},
+				},
+			},
+			{
+				Name: oldRotatingNoticesFilename,
+			},
+			{
+				Name: oldRotatingNoticesFilename + ".1",
+			},
+			{
+				Name: oldHomepageNoticeFilename,
+			},
+			{
+				Name: oldUpgradeDownloadFilename,
+			},
+			{
+				Name: "data_root_directory",
+				Children: []FileTree{
+					{
+						Name: "non_tunnel_core_file_should_not_be_clobbered",
+					},
+				},
+			},
+		},
+	}
+
+	// Write test files
+	traverseFileTree(func(tree FileTree, path string) {
+		if tree.Children == nil || len(tree.Children) == 0 {
+			if !common.FileExists(path) {
+				f, err := os.Create(path)
+				if err != nil {
+					suite.T().Fatalf("Failed to create test file %s with error: %s", path, err.Error())
+				}
+				f.Close()
+			}
+		} else {
+			if !common.FileExists(path) {
+				err := os.Mkdir(path, os.ModePerm)
+				if err != nil {
+					suite.T().Fatalf("Failed to create test directory %s with error: %s", path, err.Error())
+				}
+			}
+		}
+	}, "", oldFileTree)
+
+	// Create config with legacy config values
+	config := &Config{
+		DataRootDirectory:                            testDataRootDirectory,
+		MigrateRotatingNoticesFilename:               filepath.Join(testDirectory, oldRotatingNoticesFilename),
+		MigrateHompageNoticesFilename:                filepath.Join(testDirectory, oldHomepageNoticeFilename),
+		MigrateDataStoreDirectory:                    oldDataStoreDirectory,
+		PropagationChannelId:                         "ABCDEFGH",
+		SponsorId:                                    "12345678",
+		LocalSocksProxyPort:                          0,
+		LocalHttpProxyPort:                           0,
+		MigrateRemoteServerListDownloadFilename:      filepath.Join(testDirectory, oldRemoteServerListname),
+		MigrateObfuscatedServerListDownloadDirectory: oldObfuscatedServerListDirectory,
+		MigrateUpgradeDownloadFilename:               filepath.Join(testDirectory, oldUpgradeDownloadFilename),
+	}
+
+	// Commit config, this is where file migration happens
+	err = config.Commit()
+	if err != nil {
+		suite.T().Fatal("Error committing config:", err)
+		return
+	}
+
+	expectedNewTree := FileTree{
+		Name: testDirectory,
+		Children: []FileTree{
+			{
+				Name: "data_root_directory",
+				Children: []FileTree{
+					{
+						Name: "psiphon3_migration_complete",
+					},
+					{
+						Name: "remote_server_list",
+					},
+					{
+						Name: "remote_server_list.part",
+					},
+					{
+						Name: "remote_server_list.part.etag",
+					},
+					{
+						Name: "remote_server_list.part1",
+					},
+					{
+						Name: "remote_server_list.part1.etag",
+					},
+					{
+						Name: "datastore",
+						Children: []FileTree{
+							{
+								Name: "psiphon.boltdb",
+							},
+							{
+								Name: "psiphon.boltdb.lock",
+							},
+						},
+					},
+					{
+						Name: "osl",
+						Children: []FileTree{
+							{
+								Name: "osl-registry",
+							},
+							{
+								Name: "osl-registry.cached",
+							},
+							{
+								Name: "osl-1",
+							},
+							{
+								Name: "osl-1.part",
+							},
+						},
+					},
+					{
+						Name: "tapdance",
+						Children: []FileTree{
+							{
+								Name: "file1",
+							},
+							{
+								Name: "file2",
+							},
+						},
+					},
+					{
+						Name: "upgrade",
+					},
+					{
+						Name: "notices",
+					},
+					{
+						Name: "notices.1",
+					},
+					{
+						Name: "homepage",
+					},
+					{
+						Name: "non_tunnel_core_file_should_not_be_clobbered",
+					},
+				},
+			},
+			{
+				Name: "datastore_old",
+				Children: []FileTree{
+					{
+						Name: "non_tunnel_core_file_should_not_be_migrated",
+					},
+				},
+			},
+			{
+				Name: oldRemoteServerListname + ".should_not_be_migrated",
+			},
+			{
+				Name: oldObfuscatedServerListDirectoryName,
+			},
+		},
+	}
+
+	// Read the test directory into a file tree
+	testDirectoryTree, err := buildDirectoryTree("", testDirectory)
+	if err != nil {
+		suite.T().Fatal("Failed to build directory tree:", err)
+	}
+
+	// Enumerate the file paths, relative to the test directory,
+	// of each file in the test directory after migration.
+	testDirectoryFilePaths := make(map[string]int)
+	traverseFileTree(func(tree FileTree, path string) {
+		if val, ok := testDirectoryFilePaths[path]; ok {
+			testDirectoryFilePaths[path] = val + 1
+		} else {
+			testDirectoryFilePaths[path] = 1
+		}
+	}, "", *testDirectoryTree)
+
+	// Enumerate the file paths, relative to the test directory,
+	// of each file we expect to exist in the test directory tree
+	// after migration.
+	expectedTestDirectoryFilePaths := make(map[string]int)
+	traverseFileTree(func(tree FileTree, path string) {
+		if val, ok := expectedTestDirectoryFilePaths[path]; ok {
+			expectedTestDirectoryFilePaths[path] = val + 1
+		} else {
+			expectedTestDirectoryFilePaths[path] = 1
+		}
+	}, "", expectedNewTree)
+
+	// The set of expected file paths and set of actual  file paths should be
+	// identical.
+
+	for k, _ := range expectedTestDirectoryFilePaths {
+		_, ok := testDirectoryFilePaths[k]
+		if ok {
+			// Prevent redundant checks
+			delete(testDirectoryFilePaths, k)
+		} else {
+			suite.T().Errorf("Expected %s to exist in directory", k)
+		}
+	}
+
+	for k, _ := range testDirectoryFilePaths {
+		if _, ok := expectedTestDirectoryFilePaths[k]; !ok {
+			suite.T().Errorf("%s in directory but not expected", k)
+		}
+	}
+}
+
+// FileTree represents a file or directory in a file tree.
+// There is no need to distinguish between the two in our tests.
+type FileTree struct {
+	Name     string
+	Children []FileTree
+}
+
+// traverseFileTree traverses a file tree and emits the filepath of each node.
+//
+// For example:
+//
+//   a
+//   ├── b
+//   │   ├── 1
+//   │   └── 2
+//   └── c
+//       └── 3
+//
+// Will result in: ["a", "a/b", "a/b/1", "a/b/2", "a/c", "a/c/3"].
+func traverseFileTree(f func(node FileTree, nodePath string), basePath string, tree FileTree) {
+	filePath := filepath.Join(basePath, tree.Name)
+	f(tree, filePath)
+	if tree.Children == nil || len(tree.Children) == 0 {
+		return
+	}
+	for _, childTree := range tree.Children {
+		traverseFileTree(f, filePath, childTree)
+	}
+}
+
+// buildDirectoryTree creates a file tree, with the given directory as its root,
+// representing the directory structure that exists relative to the given directory.
+func buildDirectoryTree(basePath, directoryName string) (*FileTree, error) {
+
+	tree := &FileTree{
+		Name:     directoryName,
+		Children: nil,
+	}
+
+	dirPath := filepath.Join(basePath, directoryName)
+	files, err := ioutil.ReadDir(dirPath)
+	if err != nil {
+		return nil, errors.Tracef("Failed to read directory %s with error: %s", dirPath, err.Error())
+	}
+
+	if len(files) > 0 {
+		for _, file := range files {
+			if file.IsDir() {
+				filePath := filepath.Join(basePath, directoryName)
+				childTree, err := buildDirectoryTree(filePath, file.Name())
+				if err != nil {
+					return nil, err
+				}
+				tree.Children = append(tree.Children, *childTree)
+			} else {
+				tree.Children = append(tree.Children, FileTree{
+					Name:     file.Name(),
+					Children: nil,
+				})
+			}
+		}
+	}
+
+	return tree, nil
 }

--- a/psiphon/controller_test.go
+++ b/psiphon/controller_test.go
@@ -31,7 +31,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -485,9 +484,7 @@ func controllerRun(t *testing.T, runConfig *controllerRunConfig) {
 
 	var modifyConfig map[string]interface{}
 	json.Unmarshal(configJSON, &modifyConfig)
-	modifyConfig["DataStoreDirectory"] = testDataDirName
-	modifyConfig["RemoteServerListDownloadFilename"] = filepath.Join(testDataDirName, "server_list_compressed")
-	modifyConfig["UpgradeDownloadFilename"] = filepath.Join(testDataDirName, "upgrade")
+	modifyConfig["DataRootDirectory"] = testDataDirName
 
 	if runConfig.protocol != "" {
 		modifyConfig["LimitTunnelProtocols"] = protocol.TunnelProtocols{runConfig.protocol}

--- a/psiphon/dataStore.go
+++ b/psiphon/dataStore.go
@@ -69,7 +69,7 @@ func OpenDataStore(config *Config) error {
 		return errors.TraceNew("db already open")
 	}
 
-	newDB, err := datastoreOpenDB(config.DataStoreDirectory)
+	newDB, err := datastoreOpenDB(config.GetDataStoreDirectory())
 	if err != nil {
 		datastoreMutex.Unlock()
 		return errors.Trace(err)

--- a/psiphon/dataStoreRecovery_test.go
+++ b/psiphon/dataStoreRecovery_test.go
@@ -48,7 +48,7 @@ func TestBoltResiliency(t *testing.T) {
 
 	clientConfigJSONTemplate := `
     {
-        "DataStoreDirectory" : "%s",
+        "DataRootDirectory" : "%s",
         "ClientPlatform" : "",
         "ClientVersion" : "0",
         "SponsorId" : "0",
@@ -190,7 +190,7 @@ func TestBoltResiliency(t *testing.T) {
 	}
 
 	truncateDataStore := func() {
-		filename := filepath.Join(testDataDirName, "psiphon.boltdb")
+		filename := filepath.Join(testDataDirName, "datastore", "psiphon.boltdb")
 		configFile, err := os.OpenFile(filename, os.O_RDWR, 0666)
 		if err != nil {
 			t.Fatalf("OpenFile failed: %s", err)

--- a/psiphon/dataStoreRecovery_test.go
+++ b/psiphon/dataStoreRecovery_test.go
@@ -190,7 +190,7 @@ func TestBoltResiliency(t *testing.T) {
 	}
 
 	truncateDataStore := func() {
-		filename := filepath.Join(testDataDirName, "datastore", "psiphon.boltdb")
+		filename := filepath.Join(testDataDirName, "ca.psiphon.PsiphonTunnel.tunnel-core", "datastore", "psiphon.boltdb")
 		configFile, err := os.OpenFile(filename, os.O_RDWR, 0666)
 		if err != nil {
 			t.Fatalf("OpenFile failed: %s", err)

--- a/psiphon/dialParameters_test.go
+++ b/psiphon/dialParameters_test.go
@@ -67,7 +67,7 @@ func runDialParametersAndReplay(t *testing.T, tunnelProtocol string) {
 	clientConfig := &Config{
 		PropagationChannelId: "0",
 		SponsorId:            "0",
-		DataStoreDirectory:   testDataDirName,
+		DataRootDirectory:    testDataDirName,
 		NetworkIDGetter:      new(testNetworkGetter),
 	}
 

--- a/psiphon/exchange_test.go
+++ b/psiphon/exchange_test.go
@@ -65,7 +65,7 @@ func TestServerEntryExchange(t *testing.T) {
 		    {
                 "SponsorId" : "0",
                 "PropagationChannelId" : "0",
-		        "DataStoreDirectory" : "%s",
+		        "DataRootDirectory" : "%s",
 		        "ServerEntrySignaturePublicKey" : "%s",
 		        "ExchangeObfuscationKey" : "%s",
 		        "NetworkID" : "%s"

--- a/psiphon/limitProtocols_test.go
+++ b/psiphon/limitProtocols_test.go
@@ -107,7 +107,7 @@ func TestLimitTunnelProtocols(t *testing.T) {
 		t.Fatalf("error processing configuration file: %s", err)
 	}
 
-	clientConfig.DataStoreDirectory = testDataDirName
+	clientConfig.DataRootDirectory = testDataDirName
 
 	err = clientConfig.Commit()
 	if err != nil {

--- a/psiphon/memory_test/memory_test.go
+++ b/psiphon/memory_test/memory_test.go
@@ -99,9 +99,7 @@ func runMemoryTest(t *testing.T, testMode int) {
 	json.Unmarshal(configJSON, &modifyConfig)
 	modifyConfig["ClientVersion"] = "999999999"
 	modifyConfig["TunnelPoolSize"] = 1
-	modifyConfig["DataStoreDirectory"] = testDataDirName
-	modifyConfig["RemoteServerListDownloadFilename"] = filepath.Join(testDataDirName, "server_list_compressed")
-	modifyConfig["UpgradeDownloadFilename"] = filepath.Join(testDataDirName, "upgrade")
+	modifyConfig["DataRootDirectory"] = testDataDirName
 	modifyConfig["FetchRemoteServerListRetryPeriodMilliseconds"] = 250
 	modifyConfig["EstablishTunnelPausePeriodSeconds"] = 1
 	modifyConfig["ConnectionWorkerPoolSize"] = 10

--- a/psiphon/notice.go
+++ b/psiphon/notice.go
@@ -122,7 +122,7 @@ func SetNoticeWriter(writer io.Writer) {
 	singletonNoticeLogger.writer = writer
 }
 
-// SetNoticeFiles configures files for notice writing.
+// setNoticeFiles configures files for notice writing.
 //
 // - When homepageFilename is not "", homepages are written to the specified file
 //   and omitted from the writer. The file may be read after the Tunnels notice
@@ -140,10 +140,10 @@ func SetNoticeWriter(writer io.Writer) {
 // - If an error occurs when writing to a file, an InternalError notice is emitted to
 //   the writer.
 //
-// SetNoticeFiles closes open homepage or rotating files before applying the new
+// setNoticeFiles closes open homepage or rotating files before applying the new
 // configuration.
 //
-func SetNoticeFiles(
+func setNoticeFiles(
 	homepageFilename string,
 	rotatingFilename string,
 	rotatingFileSize int,

--- a/psiphon/remoteServerList.go
+++ b/psiphon/remoteServerList.go
@@ -41,7 +41,7 @@ type RemoteServerListFetcher func(
 // config.RemoteServerListURLs. It validates its digital signature using the
 // public key config.RemoteServerListSignaturePublicKey and parses the
 // data field into ServerEntry records.
-// config.RemoteServerListDownloadFilename is the location to store the
+// config.GetRemoteServerListDownloadFilename() is the location to store the
 // download. As the download is resumed after failure, this filename must
 // be unique and persistent.
 func FetchCommonRemoteServerList(
@@ -71,7 +71,7 @@ func FetchCommonRemoteServerList(
 		canonicalURL,
 		skipVerify,
 		"",
-		config.RemoteServerListDownloadFilename)
+		config.GetRemoteServerListDownloadFilename())
 	if err != nil {
 		return errors.Tracef("failed to download common remote server list: %s", errors.Trace(err))
 	}
@@ -81,7 +81,7 @@ func FetchCommonRemoteServerList(
 		return nil
 	}
 
-	file, err := os.Open(config.RemoteServerListDownloadFilename)
+	file, err := os.Open(config.GetRemoteServerListDownloadFilename())
 	if err != nil {
 		return errors.Tracef("failed to open common remote server list: %s", errors.Trace(err))
 
@@ -124,8 +124,8 @@ func FetchCommonRemoteServerList(
 // individual download fails, the fetch proceeds if it can.
 // Authenticated package digital signatures are validated using the
 // public key config.RemoteServerListSignaturePublicKey.
-// config.ObfuscatedServerListDownloadDirectory is the location to store the
-// downloaded files. As  downloads are resumed after failure, this directory
+// config.GetObfuscatedServerListDownloadDirectory() is the location to store
+// the downloaded files. As  downloads are resumed after failure, this directory
 // must be unique and persistent.
 func FetchObfuscatedServerLists(
 	ctx context.Context,
@@ -146,7 +146,7 @@ func FetchObfuscatedServerLists(
 	downloadURL := osl.GetOSLRegistryURL(rootURL)
 	canonicalURL := osl.GetOSLRegistryURL(canonicalRootURL)
 
-	downloadFilename := osl.GetOSLRegistryFilename(config.ObfuscatedServerListDownloadDirectory)
+	downloadFilename := osl.GetOSLRegistryFilename(config.GetObfuscatedServerListDownloadDirectory())
 	cachedFilename := downloadFilename + ".cached"
 
 	// If the cached registry is not present, we need to download or resume downloading
@@ -239,7 +239,7 @@ func FetchObfuscatedServerLists(
 		}
 
 		downloadFilename := osl.GetOSLFilename(
-			config.ObfuscatedServerListDownloadDirectory, oslFileSpec.ID)
+			config.GetObfuscatedServerListDownloadDirectory(), oslFileSpec.ID)
 
 		downloadURL := osl.GetOSLFileURL(rootURL, oslFileSpec.ID)
 		canonicalURL := osl.GetOSLFileURL(canonicalRootURL, oslFileSpec.ID)

--- a/psiphon/remoteServerList_test.go
+++ b/psiphon/remoteServerList_test.go
@@ -208,8 +208,8 @@ func testObfuscatedRemoteServerLists(t *testing.T, omitMD5Sums bool) {
 
 	config := Config{
 		DataRootDirectory:    testDataDirName,
-		PropagationChannelId: "ABCDEFGH",
-		SponsorId:            "12345678"}
+		PropagationChannelId: "0",
+		SponsorId:            "0"}
 	err = config.Commit()
 	if err != nil {
 		t.Fatalf("Error initializing config: %s", err)

--- a/psiphon/server/sessionID_test.go
+++ b/psiphon/server/sessionID_test.go
@@ -126,7 +126,7 @@ func TestDuplicateSessionID(t *testing.T) {
 
 	clientConfigJSONTemplate := `
     {
-        "DataStoreDirectory" : "%s",
+        "DataRootDirectory" : "%s",
         "SponsorId" : "0",
         "PropagationChannelId" : "0",
         "SessionID" : "00000000000000000000000000000000"

--- a/psiphon/tunnel.go
+++ b/psiphon/tunnel.go
@@ -644,7 +644,7 @@ func dialTunnel(
 		dialConn, err = tapdance.Dial(
 			ctx,
 			config.EmitTapdanceLogs,
-			config.DataStoreDirectory,
+			config.GetTapdanceDirectory(),
 			NewNetDialer(dialParams.GetDialConfig()),
 			dialParams.DirectDialAddress)
 		if err != nil {

--- a/psiphon/upgradeDownload.go
+++ b/psiphon/upgradeDownload.go
@@ -34,7 +34,7 @@ import (
 //
 // While downloading/resuming, a temporary file is used. Once the download is complete,
 // a notice is issued and the upgrade is available at the destination specified in
-// config.UpgradeDownloadFilename.
+// config.GetUpgradeDownloadFilename().
 //
 // The upgrade download may be either tunneled or untunneled. As the untunneled case may
 // happen with no handshake request response, the downloader cannot rely on having the
@@ -43,14 +43,13 @@ import (
 // remote entity's UpgradeDownloadClientVersionHeader. A HEAD request is made to check the
 // version before proceeding with a full download.
 //
-// NOTE: This code does not check that any existing file at config.UpgradeDownloadFilename
+// NOTE: This code does not check that any existing file at config.GetUpgradeDownloadFilename()
 // is actually the version specified in handshakeVersion.
 //
-// TODO: This logic requires the outer client to *omit* config.UpgradeDownloadFilename
 // when there's already a downloaded upgrade pending. Because the outer client currently
 // handles the authenticated package phase, and because the outer client deletes the
-// intermediate files (including config.UpgradeDownloadFilename), if the outer client
-// does not omit config.UpgradeDownloadFilename then the new version will be downloaded
+// intermediate files (including config.GetUpgradeDownloadFilename()), if the outer client
+// does not omit config.GetUpgradeDownloadFilename() then the new version will be downloaded
 // repeatedly. Implement a new scheme where tunnel core does the authenticated package phase
 // and tracks the the output by version number so that (a) tunnel core knows when it's not
 // necessary to re-download; (b) newer upgrades will be downloaded even when an older
@@ -68,8 +67,8 @@ func DownloadUpgrade(
 
 	// Check if complete file already downloaded
 
-	if _, err := os.Stat(config.UpgradeDownloadFilename); err == nil {
-		NoticeClientUpgradeDownloaded(config.UpgradeDownloadFilename)
+	if _, err := os.Stat(config.GetUpgradeDownloadFilename()); err == nil {
+		NoticeClientUpgradeDownloaded(config.GetUpgradeDownloadFilename())
 		return nil
 	}
 
@@ -149,10 +148,10 @@ func DownloadUpgrade(
 	// Proceed with download
 
 	// An intermediate filename is used since the presence of
-	// config.UpgradeDownloadFilename indicates a completed download.
+	// config.GetUpgradeDownloadFilename() indicates a completed download.
 
 	downloadFilename := fmt.Sprintf(
-		"%s.%s", config.UpgradeDownloadFilename, availableClientVersion)
+		"%s.%s", config.GetUpgradeDownloadFilename(), availableClientVersion)
 
 	n, _, err := ResumeDownload(
 		ctx,
@@ -168,12 +167,12 @@ func DownloadUpgrade(
 		return errors.Trace(err)
 	}
 
-	err = os.Rename(downloadFilename, config.UpgradeDownloadFilename)
+	err = os.Rename(downloadFilename, config.GetUpgradeDownloadFilename())
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	NoticeClientUpgradeDownloaded(config.UpgradeDownloadFilename)
+	NoticeClientUpgradeDownloaded(config.GetUpgradeDownloadFilename())
 
 	return nil
 }

--- a/psiphon/userAgent_test.go
+++ b/psiphon/userAgent_test.go
@@ -214,7 +214,7 @@ func attemptConnectionsWithUserAgent(
 
 	clientConfig.TargetServerEntry = string(encodedServerEntry)
 	clientConfig.TunnelProtocol = tunnelProtocol
-	clientConfig.DataStoreDirectory = testDataDirName
+	clientConfig.DataRootDirectory = testDataDirName
 
 	err = clientConfig.Commit()
 	if err != nil {


### PR DESCRIPTION
Motivation:
The core Psiphon client code allows the configuration of multiple
directories and file paths where it will store persistent files,
these files contain information such as server entries. As the
number of configurable directories and file paths increased it
became more complicated to do operations across all persisted
files, such as marking all files to be excluded from backup.

Modifications:
- Use a root data directory under which all persisted data
  will be created
- When the config is commited, migrate data files from old
  locations to their new location under the root data directory

Result:
All files persisted by the core Psiphon client are now located
under a single root data directory.