### PR TITLE
Add fronting provider ID and related tactics

### DIFF
--- a/psiphon/common/protocol/protocol_test.go
+++ b/psiphon/common/protocol/protocol_test.go
@@ -54,16 +54,32 @@ func TestTunnelProtocolValidation(t *testing.T) {
 
 func TestTLSProfileValidation(t *testing.T) {
 
-	err := SupportedTLSProfiles.Validate()
+	// Test: valid profiles
+
+	err := SupportedTLSProfiles.Validate(nil)
 	if err != nil {
 		t.Errorf("unexpected Validate error: %s", err)
 	}
 
-	invalidProfiles := TLSProfiles{"OSSH", "INVALID-PROTOCOL"}
-	err = invalidProfiles.Validate()
+	// Test: invalid profile
+
+	profiles := TLSProfiles{TLS_PROFILE_RANDOMIZED, "INVALID-TLS-PROFILE"}
+	err = profiles.Validate(nil)
 	if err == nil {
 		t.Errorf("unexpected Validate success")
 	}
+
+	// Test: valid custom profile
+
+	customProfiles := []string{"CUSTOM-TLS-PROFILE"}
+
+	profiles = TLSProfiles{TLS_PROFILE_RANDOMIZED, "CUSTOM-TLS-PROFILE"}
+	err = profiles.Validate(customProfiles)
+	if err != nil {
+		t.Errorf("unexpected Validate error: %s", err)
+	}
+
+	// Test: prune invalid profiles
 
 	pruneProfiles := make(TLSProfiles, 0)
 	for i, p := range SupportedTLSProfiles {
@@ -72,9 +88,19 @@ func TestTLSProfileValidation(t *testing.T) {
 	}
 	pruneProfiles = append(pruneProfiles, fmt.Sprintf("INVALID-PROFILE-%d", len(SupportedTLSProfiles)))
 
-	prunedProfiles := pruneProfiles.PruneInvalid()
+	prunedProfiles := pruneProfiles.PruneInvalid(nil)
 
 	if !reflect.DeepEqual(prunedProfiles, SupportedTLSProfiles) {
 		t.Errorf("unexpected %+v != %+v", prunedProfiles, SupportedTLSProfiles)
+	}
+
+	// Test: don't prune valid custom profiles
+
+	pruneProfiles = TLSProfiles{TLS_PROFILE_RANDOMIZED, "CUSTOM-TLS-PROFILE"}
+
+	prunedProfiles = pruneProfiles.PruneInvalid(customProfiles)
+
+	if !reflect.DeepEqual(prunedProfiles, pruneProfiles) {
+		t.Errorf("unexpected %+v != %+v", prunedProfiles, pruneProfiles)
 	}
 }

--- a/psiphon/common/protocol/serverEntry.go
+++ b/psiphon/common/protocol/serverEntry.go
@@ -59,6 +59,7 @@ type ServerEntry struct {
 	SshObfuscatedKey              string   `json:"sshObfuscatedKey"`
 	Capabilities                  []string `json:"capabilities"`
 	Region                        string   `json:"region"`
+	FrontingProviderID            string   `json:"frontingProviderID"`
 	MeekServerPort                int      `json:"meekServerPort"`
 	MeekCookieEncryptionPublicKey string   `json:"meekCookieEncryptionPublicKey"`
 	MeekObfuscatedKey             string   `json:"meekObfuscatedKey"`

--- a/psiphon/dialParameters.go
+++ b/psiphon/dialParameters.go
@@ -924,7 +924,7 @@ func selectQUICVersion(
 			continue
 		}
 
-		if !isFronted &&
+		if isFronted &&
 			protocol.QUICVersionIsObfuscated(quicVersion) {
 			continue
 		}

--- a/psiphon/notice.go
+++ b/psiphon/notice.go
@@ -453,6 +453,10 @@ func noticeWithDialParameters(noticeType string, dialParams *DialParameters) {
 			args = append(args, "upstreamProxyCustomHeaderNames", strings.Join(dialParams.UpstreamProxyCustomHeaderNames, ","))
 		}
 
+		if dialParams.FrontingProviderID != "" {
+			args = append(args, "frontingProviderID", dialParams.FrontingProviderID)
+		}
+
 		if dialParams.MeekDialAddress != "" {
 			args = append(args, "meekDialAddress", dialParams.MeekDialAddress)
 		}

--- a/psiphon/server/api.go
+++ b/psiphon/server/api.go
@@ -716,6 +716,7 @@ var baseRequestParams = []requestParamSpec{
 	{"ssh_client_version", isAnyString, requestParamOptional},
 	{"upstream_proxy_type", isUpstreamProxyType, requestParamOptional},
 	{"upstream_proxy_custom_header_names", isAnyString, requestParamOptional | requestParamArray},
+	{"fronting_provider_id", isAnyString, requestParamOptional | requestParamLogOnlyForFrontedMeek},
 	{"meek_dial_address", isDialAddress, requestParamOptional | requestParamLogOnlyForFrontedMeek},
 	{"meek_resolved_ip_address", isIPAddress, requestParamOptional | requestParamLogOnlyForFrontedMeek},
 	{"meek_sni_server_name", isDomain, requestParamOptional},

--- a/psiphon/server/api.go
+++ b/psiphon/server/api.go
@@ -716,7 +716,7 @@ var baseRequestParams = []requestParamSpec{
 	{"ssh_client_version", isAnyString, requestParamOptional},
 	{"upstream_proxy_type", isUpstreamProxyType, requestParamOptional},
 	{"upstream_proxy_custom_header_names", isAnyString, requestParamOptional | requestParamArray},
-	{"fronting_provider_id", isAnyString, requestParamOptional | requestParamLogOnlyForFrontedMeek},
+	{"fronting_provider_id", isAnyString, requestParamOptional},
 	{"meek_dial_address", isDialAddress, requestParamOptional | requestParamLogOnlyForFrontedMeek},
 	{"meek_resolved_ip_address", isIPAddress, requestParamOptional | requestParamLogOnlyForFrontedMeek},
 	{"meek_sni_server_name", isDomain, requestParamOptional},

--- a/psiphon/server/server_test.go
+++ b/psiphon/server/server_test.go
@@ -1163,7 +1163,7 @@ func checkExpectedLogFields(
 	//
 	// - client_build_rev not set in test build (see common/buildinfo.go)
 	// - egress_region, upstream_proxy_type, upstream_proxy_custom_header_names not exercised in test
-	// - meek_dial_ip_address/meek_resolved_ip_address only logged for FRONTED meek protocols
+	// - fronting_provider_id/meek_dial_ip_address/meek_resolved_ip_address only logged for FRONTED meek protocols
 
 	for _, name := range []string{
 		"session_id",

--- a/psiphon/serverApi.go
+++ b/psiphon/serverApi.go
@@ -825,6 +825,10 @@ func getBaseAPIParameters(
 		params["upstream_proxy_custom_header_names"] = dialParams.UpstreamProxyCustomHeaderNames
 	}
 
+	if dialParams.FrontingProviderID != "" {
+		params["fronting_provider_id"] = dialParams.FrontingProviderID
+	}
+
 	if dialParams.MeekDialAddress != "" {
 		params["meek_dial_address"] = dialParams.MeekDialAddress
 	}

--- a/psiphon/tlsDialer_test.go
+++ b/psiphon/tlsDialer_test.go
@@ -121,7 +121,7 @@ func testTLSDialerCompatibility(t *testing.T, address string) {
 		return d.DialContext(ctx, network, address)
 	}
 
-	clientParameters := makeCustomTLSProfilesClientParameters(t, false)
+	clientParameters := makeCustomTLSProfilesClientParameters(t, false, "")
 
 	profiles := append([]string(nil), protocol.SupportedTLSProfiles...)
 	profiles = append(profiles, clientParameters.Get().CustomTLSProfileNames()...)
@@ -197,7 +197,7 @@ func testTLSDialerCompatibility(t *testing.T, address string) {
 
 func TestSelectTLSProfile(t *testing.T) {
 
-	clientParameters := makeCustomTLSProfilesClientParameters(t, false)
+	clientParameters := makeCustomTLSProfilesClientParameters(t, false, "")
 
 	profiles := append([]string(nil), protocol.SupportedTLSProfiles...)
 	profiles = append(profiles, clientParameters.Get().CustomTLSProfileNames()...)
@@ -207,7 +207,7 @@ func TestSelectTLSProfile(t *testing.T) {
 	numSelections := 10000
 
 	for i := 0; i < numSelections; i++ {
-		profile := SelectTLSProfile(clientParameters.Get())
+		profile := SelectTLSProfile(false, "", clientParameters.Get())
 		selected[profile] += 1
 	}
 
@@ -282,13 +282,32 @@ func TestSelectTLSProfile(t *testing.T) {
 
 	// Only custom TLS profiles should be selected
 
-	clientParameters = makeCustomTLSProfilesClientParameters(t, true)
+	clientParameters = makeCustomTLSProfilesClientParameters(t, true, "")
 	customTLSProfileNames := clientParameters.Get().CustomTLSProfileNames()
 
 	for i := 0; i < numSelections; i++ {
-		profile := SelectTLSProfile(clientParameters.Get())
+		profile := SelectTLSProfile(false, "", clientParameters.Get())
 		if !common.Contains(customTLSProfileNames, profile) {
 			t.Errorf("unexpected non-custom TLS profile selected")
+		}
+	}
+
+	// Disabled TLS profiles should not be selected
+
+	frontingProviderID := "frontingProviderID"
+
+	clientParameters = makeCustomTLSProfilesClientParameters(t, true, frontingProviderID)
+	disableTLSProfiles := clientParameters.Get().LabeledTLSProfiles(
+		parameters.DisableFrontingProviderTLSProfiles, frontingProviderID)
+
+	if len(disableTLSProfiles) < 1 {
+		t.Errorf("unexpected disabled TLS profiles count")
+	}
+
+	for i := 0; i < numSelections; i++ {
+		profile := SelectTLSProfile(true, frontingProviderID, clientParameters.Get())
+		if common.Contains(disableTLSProfiles, profile) {
+			t.Errorf("unexpected disabled TLS profile selected")
 		}
 	}
 }
@@ -302,7 +321,7 @@ func BenchmarkRandomizedGetClientHelloVersion(b *testing.B) {
 }
 
 func makeCustomTLSProfilesClientParameters(
-	t *testing.T, useOnlyCustomTLSProfiles bool) *parameters.ClientParameters {
+	t *testing.T, useOnlyCustomTLSProfiles bool, frontingProviderID string) *parameters.ClientParameters {
 
 	clientParameters, err := parameters.NewClientParameters(nil)
 	if err != nil {
@@ -349,6 +368,20 @@ func makeCustomTLSProfilesClientParameters(
 
 	applyParameters[parameters.UseOnlyCustomTLSProfiles] = useOnlyCustomTLSProfiles
 	applyParameters[parameters.CustomTLSProfiles] = customTLSProfiles
+
+	if frontingProviderID != "" {
+		tlsProfiles := make(protocol.TLSProfiles, 0)
+		tlsProfiles = append(tlsProfiles, "CustomProfile")
+		for i, tlsProfile := range protocol.SupportedTLSProfiles {
+			if i%2 == 0 {
+				tlsProfiles = append(tlsProfiles, tlsProfile)
+			}
+		}
+		disabledTLSProfiles := make(protocol.LabeledTLSProfiles)
+		disabledTLSProfiles[frontingProviderID] = tlsProfiles
+
+		applyParameters[parameters.DisableFrontingProviderTLSProfiles] = disabledTLSProfiles
+	}
 
 	_, err = clientParameters.Set("", false, applyParameters)
 	if err != nil {


### PR DESCRIPTION
- Allows disabling incompatible TLS/QUIC versions by
  fronting provider.

- Provides a simpler method by which to query metrics
  by fronting provider.