### PR TITLE
Add Open/CloseDataStore calls to GetTactics via TacticsStorer

### DIFF
--- a/ClientLibrary/clientlib/clientlib.go
+++ b/ClientLibrary/clientlib/clientlib.go
@@ -118,7 +118,7 @@ var ErrTimeout = std_errors.New("clientlib: tunnel establishment timeout")
 func StartTunnel(ctx context.Context,
 	configJSON []byte, embeddedServerEntryList string,
 	params Parameters, paramsDelta ClientParametersDelta,
-	noticeReceiver func(NoticeEvent)) (tunnel *PsiphonTunnel, err error) {
+	noticeReceiver func(NoticeEvent)) (tunnel *PsiphonTunnel, retErr error) {
 
 	config, err := psiphon.LoadConfig(configJSON)
 	if err != nil {
@@ -176,7 +176,7 @@ func StartTunnel(ctx context.Context,
 	}
 	// Make sure we close the datastore in case of error
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			psiphon.CloseDataStore()
 		}
 	}()
@@ -287,6 +287,7 @@ func StartTunnel(ctx context.Context,
 }
 
 // Stop stops/disconnects/shuts down the tunnel. It is safe to call when not connected.
+// Not safe to call concurrently with Start.
 func (tunnel *PsiphonTunnel) Stop() {
 	if tunnel.stopController != nil {
 		tunnel.stopController()

--- a/MobileLibrary/psi/psi.go
+++ b/MobileLibrary/psi/psi.go
@@ -183,6 +183,7 @@ func Start(
 
 	controller, err = psiphon.NewController(config)
 	if err != nil {
+		psiphon.CloseDataStore()
 		return fmt.Errorf("error initializing controller: %s", err)
 	}
 

--- a/psiphon/dataStoreRecovery_test.go
+++ b/psiphon/dataStoreRecovery_test.go
@@ -216,7 +216,6 @@ func TestBoltResiliency(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenDataStore failed: %s", err)
 	}
-	defer CloseDataStore()
 
 	paveServerEntries()
 
@@ -241,7 +240,6 @@ func TestBoltResiliency(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenDataStore failed: %s", err)
 	}
-	defer CloseDataStore()
 
 	<-noticeResetDatastore
 
@@ -277,7 +275,6 @@ func TestBoltResiliency(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenDataStore failed: %s", err)
 	}
-	defer CloseDataStore()
 
 	<-noticeResetDatastore
 

--- a/psiphon/dataStore_bolt.go
+++ b/psiphon/dataStore_bolt.go
@@ -195,7 +195,7 @@ func (db *datastoreDB) close() error {
 
 func (db *datastoreDB) view(fn func(tx *datastoreTx) error) (reterr error) {
 
-	// Any bolt function that performs mmap buffer accesses can raise SIGBUS  due
+	// Any bolt function that performs mmap buffer accesses can raise SIGBUS due
 	// to underlying storage changes, such as a truncation of the datastore file
 	// or removal or network attached storage, etc.
 	//

--- a/psiphon/serverApi.go
+++ b/psiphon/serverApi.go
@@ -153,7 +153,10 @@ func (serverContext *ServerContext) doHandshakeRequest(
 		networkID = serverContext.tunnel.config.GetNetworkID()
 
 		err := tactics.SetTacticsAPIParameters(
-			serverContext.tunnel.config.clientParameters, GetTacticsStorer(), networkID, params)
+			serverContext.tunnel.config.clientParameters,
+			GetTacticsStorer(serverContext.tunnel.config),
+			networkID,
+			params)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -307,7 +310,7 @@ func (serverContext *ServerContext) doHandshakeRequest(
 		if payload != nil {
 
 			tacticsRecord, err := tactics.HandleTacticsPayload(
-				GetTacticsStorer(),
+				GetTacticsStorer(serverContext.tunnel.config),
 				networkID,
 				payload)
 			if err != nil {

--- a/psiphon/tunnel.go
+++ b/psiphon/tunnel.go
@@ -1454,7 +1454,7 @@ func (tunnel *Tunnel) sendSshKeepAlive(
 
 			err = tactics.AddSpeedTestSample(
 				tunnel.config.GetClientParameters(),
-				GetTacticsStorer(),
+				GetTacticsStorer(tunnel.config),
 				tunnel.config.GetNetworkID(),
 				tunnel.dialParams.ServerEntry.Region,
 				tunnel.dialParams.TunnelProtocol,


### PR DESCRIPTION
- Enable special case, limited multiprocess datastore synchronization.

- Allow nested OpenDataStore/CloseDataStore calls.

- Fix cases (GetSLOKs, GetDialParameters, GetTacticsRecord,
  GetSpeedTestSamplesRecord) which referenced datastore value slices outside
  a transaction.

- Fix Psiphon Library CloseDataStore cases.