### PR TITLE
Fix: spurious datastore resets

### DIFF
--- a/psiphon/dataStore_badger.go
+++ b/psiphon/dataStore_badger.go
@@ -52,7 +52,8 @@ type datastoreCursor struct {
 	prefix         []byte
 }
 
-func datastoreOpenDB(rootDataDirectory string) (*datastoreDB, error) {
+func datastoreOpenDB(
+	rootDataDirectory string, _ bool) (*datastoreDB, error) {
 
 	dbDirectory := filepath.Join(rootDataDirectory, "psiphon.badgerdb")
 

--- a/psiphon/dataStore_bolt.go
+++ b/psiphon/dataStore_bolt.go
@@ -34,7 +34,7 @@ import (
 )
 
 const (
-	OPEN_DB_RETRIES = 3
+	OPEN_DB_RETRIES = 2
 )
 
 type datastoreDB struct {
@@ -63,14 +63,14 @@ func datastoreOpenDB(
 	var db *datastoreDB
 	var err error
 
-	retries := OPEN_DB_RETRIES
-	if !retryAndReset {
-		retries = 1
+	attempts := 1
+	if retryAndReset {
+		attempts += OPEN_DB_RETRIES
 	}
 
-	for retry := 0; retry < retries; retry++ {
+	for attempt := 0; attempt < attempts; attempt++ {
 
-		db, err = tryDatastoreOpenDB(rootDataDirectory, retry > 0)
+		db, err = tryDatastoreOpenDB(rootDataDirectory, attempt > 0)
 		if err == nil {
 			break
 		}

--- a/psiphon/dataStore_files.go
+++ b/psiphon/dataStore_files.go
@@ -75,7 +75,8 @@ type datastoreCursor struct {
 	lastBuffer *bytes.Buffer
 }
 
-func datastoreOpenDB(rootDataDirectory string) (*datastoreDB, error) {
+func datastoreOpenDB(
+	rootDataDirectory string, _ bool) (*datastoreDB, error) {
 
 	dataDirectory := filepath.Join(rootDataDirectory, "psiphon.filesdb")
 	err := os.MkdirAll(dataDirectory, 0700)


### PR DESCRIPTION
Non-Controller GetTactics operations, e.g., SendFeedback, were resetting
(deleting) datastores when the Controller process held a datastore lock.

The correct behavior is for the non-Controller GetTactics to fail without
interfering with the datastore and for that operation to proceed without
tactics.

The spurious reset caused clients to lose their datastores when sending
feedback while connected to Psiphon.