### PR TITLE
Updated client platform string with Mac Catalyst and ARM Mac

### DIFF
--- a/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel.xcodeproj/project.pbxproj
+++ b/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		4E89F7FE1E2ED3CE00005F4C /* LookupIPv6.c in Sources */ = {isa = PBXBuildFile; fileRef = 4E89F7FC1E2ED3CE00005F4C /* LookupIPv6.c */; };
 		4E89F7FF1E2ED3CE00005F4C /* LookupIPv6.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E89F7FD1E2ED3CE00005F4C /* LookupIPv6.h */; };
+		52BE676825B8A615002DB553 /* PsiphonClientPlatform.h in Headers */ = {isa = PBXBuildFile; fileRef = 52BE676725B8A615002DB553 /* PsiphonClientPlatform.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		52BE676D25B8A635002DB553 /* PsiphonClientPlatform.m in Sources */ = {isa = PBXBuildFile; fileRef = 52BE676B25B8A635002DB553 /* PsiphonClientPlatform.m */; };
 		660E0B7A1E2D6EB6002BF5D4 /* Psi in Frameworks */ = {isa = PBXBuildFile; fileRef = 660E0B791E2D6EB6002BF5D4 /* Psi */; };
 		662659271DD270E900872F6C /* Reachability.h in Headers */ = {isa = PBXBuildFile; fileRef = 662659251DD270E900872F6C /* Reachability.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		662659281DD270E900872F6C /* Reachability.m in Sources */ = {isa = PBXBuildFile; fileRef = 662659261DD270E900872F6C /* Reachability.m */; };
@@ -81,6 +83,8 @@
 /* Begin PBXFileReference section */
 		4E89F7FC1E2ED3CE00005F4C /* LookupIPv6.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = LookupIPv6.c; sourceTree = "<group>"; };
 		4E89F7FD1E2ED3CE00005F4C /* LookupIPv6.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LookupIPv6.h; sourceTree = "<group>"; };
+		52BE676725B8A615002DB553 /* PsiphonClientPlatform.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PsiphonClientPlatform.h; sourceTree = "<group>"; };
+		52BE676B25B8A635002DB553 /* PsiphonClientPlatform.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PsiphonClientPlatform.m; sourceTree = "<group>"; };
 		660E0B791E2D6EB6002BF5D4 /* Psi */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = Psi; path = PsiphonTunnel/Psi.framework/Versions/A/Psi; sourceTree = "<group>"; };
 		662659251DD270E900872F6C /* Reachability.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Reachability.h; sourceTree = "<group>"; };
 		662659261DD270E900872F6C /* Reachability.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Reachability.m; sourceTree = "<group>"; };
@@ -272,6 +276,8 @@
 			children = (
 				CE3D1DA323906003009A4AF6 /* Backups.h */,
 				CE3D1DA423906003009A4AF6 /* Backups.m */,
+				52BE676725B8A615002DB553 /* PsiphonClientPlatform.h */,
+				52BE676B25B8A635002DB553 /* PsiphonClientPlatform.m */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -321,6 +327,7 @@
 				662659271DD270E900872F6C /* Reachability.h in Headers */,
 				66BDB05D1DC26CCC0079384C /* SBJson4StreamParser.h in Headers */,
 				6685BDD41E2EBB1000F0E414 /* GoPsi.objc.h in Headers */,
+				52BE676825B8A615002DB553 /* PsiphonClientPlatform.h in Headers */,
 				6685BDD51E2EBB1000F0E414 /* Universe.objc.h in Headers */,
 				CECF01492538DD0B00CD3E5C /* PsiphonProviderNetwork.h in Headers */,
 				66BDB05F1DC26CCC0079384C /* SBJson4StreamParserState.h in Headers */,
@@ -463,6 +470,7 @@
 				66BDB05E1DC26CCC0079384C /* SBJson4StreamParser.m in Sources */,
 				66BDB0641DC26CCC0079384C /* SBJson4StreamWriter.m in Sources */,
 				CEDE547A24EBF5980053566E /* PsiphonProviderFeedbackHandlerShim.m in Sources */,
+				52BE676D25B8A635002DB553 /* PsiphonClientPlatform.m in Sources */,
 				66BDB0661DC26CCC0079384C /* SBJson4StreamWriterState.m in Sources */,
 				CECF01452538D34100CD3E5C /* IPv6Synthesizer.m in Sources */,
 				66BDB05C1DC26CCC0079384C /* SBJson4Parser.m in Sources */,

--- a/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel/PsiphonTunnel.h
+++ b/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel/PsiphonTunnel.h
@@ -22,10 +22,7 @@
  *
  */
 
-#import <UIKit/UIKit.h>
 #import "Reachability.h"
-#import "JailbreakCheck.h"
-
 
 //! Project version number for PsiphonTunnel.
 FOUNDATION_EXPORT double PsiphonTunnelVersionNumber;

--- a/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel/PsiphonTunnel.m
+++ b/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel/PsiphonTunnel.m
@@ -31,11 +31,11 @@
 #import "Reachability+HasNetworkConnectivity.h"
 #import "Backups.h"
 #import "json-framework/SBJson4.h"
-#import "JailbreakCheck/JailbreakCheck.h"
 #import "NetworkID.h"
 #import <ifaddrs.h>
 #import <resolv.h>
 #import <netdb.h>
+#import "PsiphonClientPlatform.h"
 
 #define GOOGLE_DNS_1 @"8.8.4.4"
 #define GOOGLE_DNS_2 @"8.8.8.8"
@@ -795,39 +795,7 @@ typedef NS_ERROR_ENUM(PsiphonTunnelErrorDomain, PsiphonTunnelErrorCode) {
     // Fill in the rest of the values.
     //
     
-    // ClientPlatform must not contain:
-    //   - underscores, which are used by us to separate the constituent parts
-    //   - spaces, which are considered invalid by the server
-    // Like "iOS". Older iOS reports "iPhone OS", which we will convert.
-    NSString *systemName = [[UIDevice currentDevice] systemName];
-    if ([systemName isEqual: @"iPhone OS"]) {
-        systemName = @"iOS";
-    }
-    systemName = [[systemName
-                   stringByReplacingOccurrencesOfString:@"_" withString:@"-"]
-                  stringByReplacingOccurrencesOfString:@" " withString:@"-"];
-    // Like "10.2.1"
-    NSString *systemVersion = [[[[UIDevice currentDevice]systemVersion]
-                                stringByReplacingOccurrencesOfString:@"_" withString:@"-"]
-                               stringByReplacingOccurrencesOfString:@" " withString:@"-"];
-    
-    // "unjailbroken"/"jailbroken"
-    NSString *jailbroken = @"unjailbroken";
-    if ([JailbreakCheck isDeviceJailbroken]) {
-        jailbroken = @"jailbroken";
-    }
-    // Like "com.psiphon3.browser"
-    NSString *bundleIdentifier = [[[[NSBundle mainBundle] bundleIdentifier]
-                                   stringByReplacingOccurrencesOfString:@"_" withString:@"-"]
-                                  stringByReplacingOccurrencesOfString:@" " withString:@"-"];
-    
-    NSString *clientPlatform = [NSString stringWithFormat:@"%@_%@_%@_%@",
-                                systemName,
-                                systemVersion,
-                                jailbroken,
-                                bundleIdentifier];
-    
-    config[@"ClientPlatform"] = clientPlatform;
+    config[@"ClientPlatform"] = [PsiphonClientPlatform getClientPlatform];
         
     config[@"DeviceRegion"] = [PsiphonTunnel getDeviceRegion];
     

--- a/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel/Utils/PsiphonClientPlatform.h
+++ b/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel/Utils/PsiphonClientPlatform.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021, Psiphon Inc.
+ * All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface PsiphonClientPlatform : NSObject
+
+/// Returns a short description of the platform like "iOS_14.2_unjailbroken_ca.psiphon.Psiphon" if running on iOS
+/// or "iOS_13.1_iOSAppOnMac_ca.psiphon.Psiphon" if running as an iOS build on an ARM Mac.
++ (NSString *)getClientPlatform;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel/Utils/PsiphonClientPlatform.m
+++ b/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel/Utils/PsiphonClientPlatform.m
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2021, Psiphon Inc.
+ * All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#import "PsiphonClientPlatform.h"
+#import <UIKit/UIKit.h>
+#import "JailbreakCheck.h"
+
+@implementation PsiphonClientPlatform
+
++ (NSString *)getClientPlatform {
+    // ClientPlatform must not contain:
+    //   - underscores, which are used by us to separate the constituent parts
+    //   - spaces, which are considered invalid by the server
+    // Like "iOS". Older iOS reports "iPhone OS", which we will convert.
+    NSString *systemName = [[UIDevice currentDevice] systemName];
+
+    if ([systemName isEqual: @"iPhone OS"]) {
+        systemName = @"iOS";
+    }
+    systemName = [[systemName
+                   stringByReplacingOccurrencesOfString:@"_" withString:@"-"]
+                  stringByReplacingOccurrencesOfString:@" " withString:@"-"];
+
+    // Like "10.2.1"
+    NSString *systemVersion = [[[[UIDevice currentDevice]systemVersion]
+                                stringByReplacingOccurrencesOfString:@"_" withString:@"-"]
+                               stringByReplacingOccurrencesOfString:@" " withString:@"-"];
+
+    // The value of this property is YES only when the process is an iOS app running on a Mac.
+    // The value of the property is NO for all other apps on the Mac, including Mac apps built
+    // using Mac Catalyst. The property is also NO for processes running on platforms other than macOS.
+    BOOL isiOSAppOnMac = FALSE;
+    if (@available(iOS 14.0, *)) {
+        isiOSAppOnMac = [[NSProcessInfo processInfo] isiOSAppOnMac];
+    }
+
+    // The value of this property is true when the process is:
+    // - A Mac app built with Mac Catalyst, or an iOS app running on Apple silicon.
+    // - Running on a Mac.
+    BOOL isMacCatalystApp = FALSE;
+    if (@available(iOS 14.0, *)) {
+        isMacCatalystApp = [[NSProcessInfo processInfo] isMacCatalystApp];
+    }
+
+    // Possible values are: "unjailbroken"/"jailbroken"/"iOSAppOnMac"/"MacCatalystApp"
+    // Note that on Macs, users have root access, unlike iOS, where
+    // the user has to jailbreak the device to get root access.
+    NSString *detail = @"unjailbroken";
+
+    if (isiOSAppOnMac == TRUE && isMacCatalystApp == TRUE) {
+        detail = @"iOSAppOnMac";
+    } else if (isiOSAppOnMac == FALSE && isMacCatalystApp == TRUE) {
+        detail = @"MacCatalystApp";
+    } else {
+        // App is an iOS app running on iOS.
+        if ([JailbreakCheck isDeviceJailbroken] == TRUE) {
+            detail = @"jailbroken";
+        }
+    }
+
+    // Like "com.psiphon3.browser"
+    NSString *bundleIdentifier = [[[[NSBundle mainBundle] bundleIdentifier]
+                                   stringByReplacingOccurrencesOfString:@"_" withString:@"-"]
+                                  stringByReplacingOccurrencesOfString:@" " withString:@"-"];
+
+    NSString *clientPlatform = [NSString stringWithFormat:@"%@_%@_%@_%@",
+                                systemName,
+                                systemVersion,
+                                detail,
+                                bundleIdentifier];
+
+    return clientPlatform;
+}
+
+@end


### PR DESCRIPTION
Modifications:
- Added MacCatalyst and iOSAppOnMac details to client platform string.
- Make PsiphonClientPlatform header public.