### PR TITLE
Mitigate "permission denied" errors when writing logs

### DIFF
--- a/Server/main.go
+++ b/Server/main.go
@@ -301,7 +301,10 @@ func panicHandler(output string) {
 		// Logs are written to the configured file name. If no name is specified, logs are written to stderr
 		var jsonWriter io.Writer
 		if config.LogFilename != "" {
-			panicLog, err := rotate.NewRotatableFileWriter(config.LogFilename, 0666)
+
+			retries, create, mode := config.GetLogFileReopenConfig()
+			panicLog, err := rotate.NewRotatableFileWriter(
+				config.LogFilename, retries, create, mode)
 			if err != nil {
 				fmt.Printf("unable to set panic log output: %s\n%s\n", err, output)
 				os.Exit(1)

--- a/psiphon/server/log.go
+++ b/psiphon/server/log.go
@@ -263,7 +263,10 @@ func InitLogging(config *Config) (retErr error) {
 		var logWriter io.Writer
 
 		if config.LogFilename != "" {
-			logWriter, err = rotate.NewRotatableFileWriter(config.LogFilename, 0666)
+
+			retries, create, mode := config.GetLogFileReopenConfig()
+			logWriter, err = rotate.NewRotatableFileWriter(
+				config.LogFilename, retries, create, mode)
 			if err != nil {
 				retErr = errors.Trace(err)
 				return

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -15,10 +15,10 @@
 			"revisionTime": "2017-07-02T08:40:17Z"
 		},
 		{
-			"checksumSHA1": "aFs1ojFW1UmUNMtN6rdRJ2FEIRE=",
+			"checksumSHA1": "sfwh75+6RErl2wUTOYb5PSVm7ik=",
 			"path": "github.com/Psiphon-Inc/rotate-safe-writer",
-			"revision": "b276127301a99aa7102ebdc6f509fc8d890900d0",
-			"revisionTime": "2017-02-28T16:03:01Z"
+			"revision": "464a7a37606efa061cb3021e7bb9fa3642e1e74d",
+			"revisionTime": "2021-03-03T14:09:23Z"
 		},
 		{
 			"checksumSHA1": "okYVKU03vmD+0tpqfhvXEubcaCw=",


### PR DESCRIPTION
- Add retries when reopening log files after rotation.

- Don't attempt to create new log files unless necessary.