### PR TITLE
fix: use the correct spelling of marionette

### DIFF
--- a/psiphon/dialParameters.go
+++ b/psiphon/dialParameters.go
@@ -773,7 +773,7 @@ func MakeDialParameters(
 
 	case protocol.TUNNEL_PROTOCOL_MARIONETTE_OBFUSCATED_SSH:
 
-		// Note: port comes from marionnete "format"
+		// Note: port comes from marionette "format"
 		dialParams.DirectDialAddress = serverEntry.IpAddress
 
 	default:


### PR DESCRIPTION
This occurred to me while reading the diff after fetching new changes from the `staging-client` branch.