### PR TITLE
Support .so Library Load by Consumer

### DIFF
--- a/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
+++ b/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
@@ -92,7 +92,13 @@ public class PsiphonTunnel {
         default public void sendFeedbackCompleted(java.lang.Exception e) {}
     }
 
-    public interface HostService extends HostLogger {
+    public interface HostLibraryLoader {
+        default public void loadLibrary(String library) {
+            System.loadLibrary(library);
+        }
+    }
+
+    public interface HostService extends HostLogger, HostLibraryLoader {
 
         public String getAppName();
         public Context getContext();
@@ -158,7 +164,7 @@ public class PsiphonTunnel {
             mPsiphonTunnel.stop();
         }
         // Load the native go code embedded in psi.aar
-        System.loadLibrary("gojni");
+        hostService.loadLibrary("gojni");
         mPsiphonTunnel = new PsiphonTunnel(hostService, shouldRouteThroughTunnelAutomatically);
         return mPsiphonTunnel;
     }
@@ -227,7 +233,7 @@ public class PsiphonTunnel {
         // Load tun2socks library embedded in the aar
         // If this method is called more than once with the same library name, the second and subsequent calls are ignored.
         // http://docs.oracle.com/javase/7/docs/api/java/lang/Runtime.html#loadLibrary%28java.lang.String%29
-        System.loadLibrary("tun2socks");
+        mHostService.loadLibrary("tun2socks");
         return startVpn();
     }
 

--- a/contributors/pfarcasanu.md
+++ b/contributors/pfarcasanu.md
@@ -1,0 +1,9 @@
+2022-04-12
+
+I hereby agree to the terms of the "Psiphon Individual Contributor License Agreement", with MD5 checksum 83d54c85a43e0c0f416758779ea6740a.
+
+I furthermore declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Paul Farcasanu https://github.com/pfarcasanu


### PR DESCRIPTION
**Context**
Currently, the Psiphon java layer calls directly into `System.loadLibrary` to load `.so` libraries. This system call may not play nicely with certain infrastructures, leading to `UnsatisfiedLinkError` exceptions. 

**Design**
In order to keep Psiphon implementation modular, I am adding a default overridable method to HostService. If the customer chooses, they can use their own lib load implementation to ensure `.so` libraries are loaded.

**Test Plan**
Followed build steps to produce a new `.aar` and integrated with it, supplying custom `libraryLoad` implementation. Confirm that libraries are loaded without error and Psiphon spins up. 