### PR TITLE
Fix: ensure build disables modules

### DIFF
--- a/ClientLibrary/example/Makefile
+++ b/ClientLibrary/example/Makefile
@@ -5,7 +5,8 @@ main.o: main.c
 	gcc -I.. -c main.c
 
 libpsiphontunnel.so: ../PsiphonTunnel.go
-	go build -buildmode=c-shared -o libpsiphontunnel.so ../PsiphonTunnel.go
+	# At this time, we don't support modules
+	GO111MODULE=off go build -buildmode=c-shared -o libpsiphontunnel.so ../PsiphonTunnel.go
 
 clean:
 	rm libpsiphontunnel.so libpsiphontunnel.h main main.o


### PR DESCRIPTION
- With Go 1.13, ClientLibrary/example/make fails without GO111MODULE=off.