### PR TITLE
Fix linux Docker builds

### DIFF
--- a/ClientLibrary/README.md
+++ b/ClientLibrary/README.md
@@ -57,10 +57,13 @@ Note that you may need to use `sudo docker` below, depending on your OS.
 
 *Ensure that the command below is run from within the `ClientLibrary` directory*
 
+*The `--user "$(id -u):$(id -g)"` flag must be omitted when building on macOS because manually specifying the UID/GID will cause the build to fail since Docker on macOS handles host to container UID/GID mapping automatically and will be unable to map the manually specified UID/GID to the current user.*
+
 ```bash
 cd .. && \
   docker run \
   --platform=linux/amd64 \
+  --user "$(id -u):$(id -g)" \
   --rm \
   -v $PWD:/go/src/github.com/Psiphon-Labs/psiphon-tunnel-core \
   psiclientlibrary-builder \

--- a/ClientLibrary/build-darwin.sh
+++ b/ClientLibrary/build-darwin.sh
@@ -80,6 +80,8 @@ prepare_build () {
   BUILDREV=$(git rev-parse --short HEAD)
   GOVERSION=$(go version | perl -ne '/go version (.*?) / && print $1')
 
+  cd ${GOPATH}/src/github.com/Psiphon-Labs/psiphon-tunnel-core/ClientLibrary
+
   LDFLAGS="\
   -s \
   -w \

--- a/ClientLibrary/make.bash
+++ b/ClientLibrary/make.bash
@@ -10,6 +10,8 @@ fi
 # $2, if specified, is go build tags
 if [ -z ${2+x} ]; then BUILD_TAGS=""; else BUILD_TAGS="$2"; fi
 
+export GOCACHE=/tmp
+
 BUILD_DIR=build
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/ConsoleClient/README.md
+++ b/ConsoleClient/README.md
@@ -14,10 +14,13 @@ Note that you may need to use `sudo docker` below, depending on your OS.
 
 *Ensure that the command below is run from within the `ConsoleClient` directory*
 
+*The `--user "$(id -u):$(id -g)"` flag must be omitted when building on macOS because manually specifying the UID/GID will cause the build to fail since Docker on macOS handles host to container UID/GID mapping automatically and will be unable to map the manually specified UID/GID to the current user.*
+
 ```bash
 cd .. && \
   docker run \
   --platform=linux/amd64 \
+  --user "$(id -u):$(id -g)" \
   --rm \
   -v $PWD:/go/src/github.com/Psiphon-Labs/psiphon-tunnel-core \
   psiclient \

--- a/ConsoleClient/make.bash
+++ b/ConsoleClient/make.bash
@@ -10,6 +10,8 @@ fi
 # $2, if specified, is go build tags
 if [ -z ${2+x} ]; then BUILD_TAGS=""; else BUILD_TAGS="$2"; fi
 
+export GOCACHE=/tmp
+
 EXE_BASENAME="psiphon-tunnel-core"
 
 prepare_build () {

--- a/MobileLibrary/Android/README.md
+++ b/MobileLibrary/Android/README.md
@@ -48,10 +48,13 @@ Note that you may need to use `sudo docker` below, depending on your OS.
 
 *Ensure that the command below is run from within the `MobileLibrary/Android` directory*
 
+*The `--user "$(id -u):$(id -g)"` flag must be omitted when building on macOS because manually specifying the UID/GID will cause the build to fail since Docker on macOS handles host to container UID/GID mapping automatically and will be unable to map the manually specified UID/GID to the current user.*
+
 ```bash
 cd ../.. && \
   docker run \
   --platform=linux/amd64 \
+  --user "$(id -u):$(id -g)" \
   --rm \
   -v $(pwd):/go/src/github.com/Psiphon-Labs/psiphon-tunnel-core \
   psiandroid \

--- a/MobileLibrary/Android/make.bash
+++ b/MobileLibrary/Android/make.bash
@@ -13,6 +13,8 @@ if [ -z ${1+x} ]; then BUILD_TAGS=""; else BUILD_TAGS="$1"; fi
 # At this time, psiphon-tunnel-core doesn't support modules
 export GO111MODULE=off
 
+export GOCACHE=/tmp
+
 BUILDINFOFILE="psiphon-tunnel-core_buildinfo.txt"
 BUILDDATE=$(date --iso-8601=seconds)
 BUILDREPO=$(git config --get remote.origin.url)

--- a/Server/make.bash
+++ b/Server/make.bash
@@ -13,6 +13,8 @@ fi
 # $1, if specified, is go build tags
 if [ -z ${1+x} ]; then BUILD_TAGS=""; else BUILD_TAGS="$1"; fi
 
+export GOCACHE=/tmp
+
 prepare_build () {
   BUILDINFOFILE="psiphond_buildinfo.txt"
   BUILDDATE=$(date -Iseconds)


### PR DESCRIPTION
- Fix UID/GID mapping issues between host and container when building on Linux
- Set GOCACHE to a directory the user executing the container will have write permissions for
- Fix build-darwin.sh