### PR TITLE
Use active interface IP address for network ID on mobile

### DIFF
--- a/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel/Network/NetworkInterface.h
+++ b/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel/Network/NetworkInterface.h
@@ -43,6 +43,13 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSString*)getActiveInterfaceWithReachability:(id<ReachabilityProtocol>)reachability
                         andCurrentNetworkStatus:(NetworkReachability)currentNetworkStatus
                                           error:(NSError *_Nullable *_Nonnull)outError;
+/// Returns the active interface address.
+/// @param reachability ReachabilityProtocol implementer used to determine active interface on iOS >=12.
+/// @param currentNetworkStatus Used to determine active interface on iOS <12.
+/// @param outError If non-nil, then an error occurred while determining the active interface.
++ (NSString*)getActiveInterfaceAddressWithReachability:(id<ReachabilityProtocol>)reachability
+                               andCurrentNetworkStatus:(NetworkReachability)currentNetworkStatus
+                                                 error:(NSError *_Nullable *_Nonnull)outError;
 
 @end
 

--- a/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel/Network/NetworkInterface.m
+++ b/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel/Network/NetworkInterface.m
@@ -226,4 +226,49 @@
     return activeInterface;
 }
 
++ (NSString*)getActiveInterfaceAddressWithReachability:(id<ReachabilityProtocol>)reachability
+                               andCurrentNetworkStatus:(NetworkReachability)currentNetworkStatus
+                                                 error:(NSError *_Nullable *_Nonnull)outError {
+
+    *outError = nil;
+
+    NSError *err;
+    NSString *activeInterface =
+        [NetworkInterface getActiveInterfaceWithReachability:reachability
+                                     andCurrentNetworkStatus:currentNetworkStatus
+                                                       error:&err];
+    if (err != nil) {
+        NSString *localizedDescription = [NSString stringWithFormat:@"error getting active interface %@", err.localizedDescription];
+        *outError = [[NSError alloc] initWithDomain:@"iOSLibrary"
+                                               code:1
+                                           userInfo:@{NSLocalizedDescriptionKey:localizedDescription}];
+        return @"";
+    } else if (activeInterface == nil) {
+        NSString *localizedDescription = @"active interface nil";
+        *outError = [[NSError alloc] initWithDomain:@"iOSLibrary"
+                                               code:1
+                                           userInfo:@{NSLocalizedDescriptionKey:localizedDescription}];
+        return @"";
+    }
+
+    NSString *interfaceAddress = [NetworkInterface getInterfaceAddress:activeInterface
+                                                                 error:&err];
+    if (err != nil) {
+        NSString *localizedDescription =
+            [NSString stringWithFormat:@"error getting interface address %@", err.localizedDescription];
+        *outError = [[NSError alloc] initWithDomain:@"iOSLibrary"
+                                               code:1
+                                           userInfo:@{NSLocalizedDescriptionKey:localizedDescription}];
+        return @"";
+    } else if (interfaceAddress == nil) {
+        NSString *localizedDescription = @"interface address nil";
+        *outError = [[NSError alloc] initWithDomain:@"iOSLibrary"
+                                               code:1
+                                           userInfo:@{NSLocalizedDescriptionKey:localizedDescription}];
+        return @"";
+    }
+
+    return interfaceAddress;
+}
+
 @end


### PR DESCRIPTION
CTCarrier methods deprecated in iOS 16.0 and now return static value 65535.