### PR TITLE
Add steering IP mechanism

### DIFF
--- a/psiphon/common/parameters/parameters.go
+++ b/psiphon/common/parameters/parameters.go
@@ -365,6 +365,9 @@ const (
 	TLSTunnelMaxTLSPadding                           = "TLSTunnelMaxTLSPadding"
 	TLSFragmentClientHelloProbability                = "TLSFragmentClientHelloProbability"
 	TLSFragmentClientHelloLimitProtocols             = "TLSFragmentClientHelloLimitProtocols"
+	SteeringIPCacheTTL                               = "SteeringIPCacheTTL"
+	SteeringIPCacheMaxEntries                        = "SteeringIPCacheMaxEntries"
+	SteeringIPProbability                            = "SteeringIPProbability"
 
 	// Retired parameters
 
@@ -779,6 +782,10 @@ var defaultParameters = map[string]struct {
 
 	TLSFragmentClientHelloProbability:    {value: 0.0, minimum: 0.0},
 	TLSFragmentClientHelloLimitProtocols: {value: protocol.TunnelProtocols{}},
+
+	SteeringIPCacheTTL:        {value: 1 * time.Hour, minimum: time.Duration(0)},
+	SteeringIPCacheMaxEntries: {value: 65536, minimum: 0},
+	SteeringIPProbability:     {value: 1.0, minimum: 0.0},
 }
 
 // IsServerSideOnly indicates if the parameter specified by name is used

--- a/psiphon/common/protocol/protocol.go
+++ b/psiphon/common/protocol/protocol.go
@@ -600,6 +600,7 @@ type HandshakeResponse struct {
 	TacticsPayload           json.RawMessage     `json:"tactics_payload"`
 	UpstreamBytesPerSecond   int64               `json:"upstream_bytes_per_second"`
 	DownstreamBytesPerSecond int64               `json:"downstream_bytes_per_second"`
+	SteeringIP               string              `json:"steering_ip"`
 	Padding                  string              `json:"padding"`
 }
 

--- a/psiphon/common/protocol/serverEntry.go
+++ b/psiphon/common/protocol/serverEntry.go
@@ -33,6 +33,7 @@ import (
 	"io"
 	"net"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common"
@@ -675,7 +676,7 @@ func (serverEntry *ServerEntry) GetDialPortNumber(tunnelProtocol string) (int, e
 
 	case TUNNEL_PROTOCOL_FRONTED_MEEK,
 		TUNNEL_PROTOCOL_FRONTED_MEEK_QUIC_OBFUSCATED_SSH:
-		return 443, nil
+		return int(atomic.LoadInt32(&frontedMeekHTTPSDialPortNumber)), nil
 
 	case TUNNEL_PROTOCOL_FRONTED_MEEK_HTTP:
 		return 80, nil
@@ -687,6 +688,15 @@ func (serverEntry *ServerEntry) GetDialPortNumber(tunnelProtocol string) (int, e
 	}
 
 	return 0, errors.TraceNew("unknown protocol")
+}
+
+var frontedMeekHTTPSDialPortNumber = int32(443)
+
+// SetFrontedMeekHTTPDialPortNumber sets the FRONTED-MEEK-OSSH dial port
+// number, which defaults to 443. Overriding the port number enables running
+// test servers where binding to port 443 is not possible.
+func SetFrontedMeekHTTPDialPortNumber(port int) {
+	atomic.StoreInt32(&frontedMeekHTTPSDialPortNumber, int32(port))
 }
 
 // GetSupportedTacticsProtocols returns a list of tunnel protocols,

--- a/psiphon/dialParameters.go
+++ b/psiphon/dialParameters.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"crypto/md5"
 	"encoding/binary"
+	"fmt"
 	"net"
 	"net/http"
 	"strconv"
@@ -42,6 +43,7 @@ import (
 	"github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/resolver"
 	"github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/transforms"
 	"github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/values"
+	lrucache "github.com/cognusion/go-cache-lru"
 	"golang.org/x/net/bpf"
 )
 
@@ -159,6 +161,10 @@ type DialParameters struct {
 
 	HTTPTransformerParameters *transforms.HTTPTransformerParameters
 
+	SteeringIP         string
+	steeringIPCache    *lrucache.Cache `json:"-"`
+	steeringIPCacheKey string          `json:"-"`
+
 	dialConfig *DialConfig `json:"-"`
 	meekConfig *MeekConfig `json:"-"`
 }
@@ -182,6 +188,7 @@ type DialParameters struct {
 // when establishment is cancelled.
 func MakeDialParameters(
 	config *Config,
+	steeringIPCache *lrucache.Cache,
 	upstreamProxyErrorCallback func(error),
 	canReplay func(serverEntry *protocol.ServerEntry, replayProtocol string) bool,
 	selectProtocol func(serverEntry *protocol.ServerEntry) (string, bool),
@@ -337,12 +344,6 @@ func MakeDialParameters(
 		dialParams = &DialParameters{}
 	}
 
-	// Point to the current resolver to be used in dials.
-	dialParams.resolver = config.GetResolver()
-	if dialParams.resolver == nil {
-		return nil, errors.TraceNew("missing resolver")
-	}
-
 	if isExchanged {
 		// Set isReplay to false to cause all non-exchanged values to be
 		// initialized; this also causes the exchange case to not log as replay.
@@ -352,6 +353,14 @@ func MakeDialParameters(
 	// Set IsExchanged such that full dial parameters are stored and replayed
 	// upon success.
 	dialParams.IsExchanged = false
+
+	// Point to the current resolver to be used in dials.
+	dialParams.resolver = config.GetResolver()
+	if dialParams.resolver == nil {
+		return nil, errors.TraceNew("missing resolver")
+	}
+
+	dialParams.steeringIPCache = steeringIPCache
 
 	dialParams.ServerEntry = serverEntry
 	dialParams.NetworkID = networkID
@@ -1142,6 +1151,94 @@ func MakeDialParameters(
 
 	// Initialize Dial/MeekConfigs to be passed to the corresponding dialers.
 
+	var resolveIP func(ctx context.Context, hostname string) ([]net.IP, error)
+
+	// Determine whether to use a steering IP, and whether to indicate that
+	// this dial remains a replay or not.
+	//
+	// Steering IPs are used only for fronted tunnels and not lower-traffic
+	// tactics requests and signalling steps such as Conjure registration.
+	//
+	// The scope of the steering IP, and the corresponding cache key, is the
+	// fronting provider, tunnel protocol, and the current network ID.
+	//
+	// Currently, steering IPs are obtained and cached in the Psiphon API
+	// handshake response. A modest TTL is applied to cache entries, and, in
+	// the case of a failed tunnel, any corresponding cached steering IP is
+	// removed.
+	//
+	// DialParameters.SteeringIP is set and persisted, but is not used to dial
+	// in a replay case; it's used to determine whether this dial should be
+	// classified as a replay or not. A replay dial remains classified as
+	// replay if a steering IP is not used and no steering IP was used
+	// before; or when a steering IP is used and the same steering IP was
+	// used before.
+	//
+	// When a steering IP is used and none was used before, or vice versa,
+	// DialParameters.IsReplay is cleared so that is_replay is reported as
+	// false, since the dial may be very different in nature: using a
+	// different POP; skipping DNS; etc. Even if DialParameters.IsReplay was
+	// true and is cleared, this MakeDialParameters will have wired up all
+	// other dial parameters with replay values, so the benefit of those
+	// values is not lost.
+
+	var previousSteeringIP, currentSteeringIP string
+	if isReplay {
+		previousSteeringIP = dialParams.SteeringIP
+	}
+	dialParams.SteeringIP = ""
+
+	if !isTactics &&
+		protocol.TunnelProtocolUsesFrontedMeek(dialParams.TunnelProtocol) &&
+		dialParams.ServerEntry.FrontingProviderID != "" {
+
+		dialParams.steeringIPCacheKey = fmt.Sprintf("%s %s %s",
+			dialParams.NetworkID,
+			dialParams.ServerEntry.FrontingProviderID,
+			dialParams.TunnelProtocol)
+
+		steeringIPValue, ok := dialParams.steeringIPCache.Get(
+			dialParams.steeringIPCacheKey)
+		if ok {
+			currentSteeringIP = steeringIPValue.(string)
+		}
+
+		// A steering IP probability is applied and may be used to gradually
+		// apply steering IPs. The coin flip is made only to decide to start
+		// using a steering IP, avoiding flip flopping between dials. For any
+		// probability > 0.0, a long enough continuous session will
+		// eventually flip to true and then keep using steering IPs as long
+		// as they remain in the cache.
+
+		if previousSteeringIP == "" && currentSteeringIP != "" &&
+			!p.WeightedCoinFlip(parameters.SteeringIPProbability) {
+
+			currentSteeringIP = ""
+		}
+	}
+
+	if currentSteeringIP != "" {
+		IP := net.ParseIP(currentSteeringIP)
+		if IP == nil {
+			return nil, errors.TraceNew("invalid steering IP")
+		}
+
+		// Since tcpDial and NewUDPConn invoke ResolveIP unconditionally, even
+		// when the hostname is an IP address, a steering IP will be applied
+		// even in that case.
+		resolveIP = func(ctx context.Context, hostname string) ([]net.IP, error) {
+			return []net.IP{IP}, nil
+		}
+
+		// dialParams.SteeringIP will be used as the "previous" steering IP in
+		// the next replay.
+		dialParams.SteeringIP = currentSteeringIP
+	}
+
+	if currentSteeringIP != previousSteeringIP {
+		dialParams.IsReplay = false
+	}
+
 	// Custom ResolveParameters are set only when useResolver is true, but
 	// DialConfig.ResolveIP is required and wired up unconditionally. Any
 	// misconfigured or miscoded domain dial cases will use default
@@ -1150,16 +1247,18 @@ func MakeDialParameters(
 	// ResolveIP will use the networkID obtained above, as it will be used
 	// almost immediately, instead of incurring the overhead of calling
 	// GetNetworkID again.
-	resolveIP := func(ctx context.Context, hostname string) ([]net.IP, error) {
-		IPs, err := dialParams.resolver.ResolveIP(
-			ctx,
-			networkID,
-			dialParams.ResolveParameters,
-			hostname)
-		if err != nil {
-			return nil, errors.Trace(err)
+	if resolveIP == nil {
+		resolveIP = func(ctx context.Context, hostname string) ([]net.IP, error) {
+			IPs, err := dialParams.resolver.ResolveIP(
+				ctx,
+				networkID,
+				dialParams.ResolveParameters,
+				hostname)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			return IPs, nil
 		}
-		return IPs, nil
 	}
 
 	// Fragmentor configuration.
@@ -1232,6 +1331,7 @@ func MakeDialParameters(
 			MeekObfuscatorPaddingSeed:     dialParams.MeekObfuscatorPaddingSeed,
 			NetworkLatencyMultiplier:      dialParams.NetworkLatencyMultiplier,
 			HTTPTransformerParameters:     dialParams.HTTPTransformerParameters,
+			AdditionalHeaders:             config.MeekAdditionalHeaders,
 		}
 
 		// Use an asynchronous callback to record the resolved IP address when
@@ -1349,6 +1449,16 @@ func (dialParams *DialParameters) Failed(config *Config) {
 		if err != nil {
 			NoticeWarning("DeleteDialParameters failed: %s", err)
 		}
+	}
+
+	// When a failed tunnel dialed with steering IP, remove the corresponding
+	// cache entry to avoid continuously redialing a potentially blocked or
+	// degraded POP.
+	//
+	// TODO: don't remove, but reduce the TTL to allow for one more dial?
+
+	if dialParams.steeringIPCacheKey != "" {
+		dialParams.steeringIPCache.Delete(dialParams.steeringIPCacheKey)
 	}
 }
 

--- a/psiphon/exchange_test.go
+++ b/psiphon/exchange_test.go
@@ -186,6 +186,7 @@ func TestServerEntryExchange(t *testing.T) {
 			dialParams, err := MakeDialParameters(
 				config,
 				nil,
+				nil,
 				canReplay,
 				selectProtocol,
 				serverEntry,

--- a/psiphon/meekConn.go
+++ b/psiphon/meekConn.go
@@ -210,6 +210,11 @@ type MeekConfig struct {
 	// HTTPTransformerParameters specifies an HTTP transformer to apply to the
 	// meek connection if it uses HTTP.
 	HTTPTransformerParameters *transforms.HTTPTransformerParameters
+
+	// AdditionalHeaders is a set of additional arbitrary HTTP headers that
+	// are added to all meek HTTP requests. An additional header is ignored
+	// when the header name is already present in a meek request.
+	AdditionalHeaders http.Header
 }
 
 // MeekConn is a network connection that tunnels net.Conn flows over HTTP and supports
@@ -679,6 +684,14 @@ func DialMeek(
 			return nil, errors.Trace(err)
 		}
 		additionalHeaders.Set("X-Psiphon-Fronting-Address", host)
+	}
+
+	if meekConfig.AdditionalHeaders != nil {
+		for name, value := range meekConfig.AdditionalHeaders {
+			if _, ok := additionalHeaders[name]; !ok {
+				additionalHeaders[name] = value
+			}
+		}
 	}
 
 	meek.url = url

--- a/psiphon/notice.go
+++ b/psiphon/notice.go
@@ -490,6 +490,7 @@ func noticeWithDialParameters(noticeType string, dialParams *DialParameters, pos
 		}
 
 		if protocol.TunnelProtocolUsesFrontedMeek(dialParams.TunnelProtocol) {
+
 			meekResolvedIPAddress := dialParams.MeekResolvedIPAddress.Load().(string)
 			if meekResolvedIPAddress != "" {
 				nonredacted := common.EscapeRedactIPAddressString(meekResolvedIPAddress)
@@ -571,7 +572,15 @@ func noticeWithDialParameters(noticeType string, dialParams *DialParameters, pos
 			args = append(args, "conjureTransport", dialParams.ConjureTransport)
 		}
 
-		if dialParams.ResolveParameters != nil {
+		usedSteeringIP := false
+
+		if dialParams.SteeringIP != "" {
+			nonredacted := common.EscapeRedactIPAddressString(dialParams.SteeringIP)
+			args = append(args, "steeringIP", nonredacted)
+			usedSteeringIP = true
+		}
+
+		if dialParams.ResolveParameters != nil && !usedSteeringIP {
 
 			// See dialParams.ResolveParameters comment in getBaseAPIParameters.
 

--- a/psiphon/server/api.go
+++ b/psiphon/server/api.go
@@ -401,6 +401,7 @@ func handshakeAPIRequestHandler(
 		TacticsPayload:           marshaledTacticsPayload,
 		UpstreamBytesPerSecond:   handshakeStateInfo.upstreamBytesPerSecond,
 		DownstreamBytesPerSecond: handshakeStateInfo.downstreamBytesPerSecond,
+		SteeringIP:               handshakeStateInfo.steeringIP,
 		Padding:                  strings.Repeat(" ", pad_response),
 	}
 
@@ -972,6 +973,7 @@ var baseDialParams = []requestParamSpec{
 	{"tls_padding", isIntString, requestParamOptional | requestParamLogStringAsInt},
 	{"tls_ossh_sni_server_name", isDomain, requestParamOptional},
 	{"tls_ossh_transformed_host_name", isBooleanFlag, requestParamOptional | requestParamLogFlagAsBool},
+	{"steering_ip", isIPAddress, requestParamOptional | requestParamLogOnlyForFrontedMeekOrConjure},
 }
 
 // baseSessionAndDialParams adds baseDialParams to baseSessionParams.

--- a/psiphon/server/config.go
+++ b/psiphon/server/config.go
@@ -792,6 +792,7 @@ type GenerateConfigParams struct {
 	LegacyPassthrough                  bool
 	LimitQUICVersions                  protocol.QUICVersions
 	EnableGQUIC                        bool
+	FrontingProviderID                 string
 }
 
 // GenerateConfig creates a new Psiphon server config. It returns JSON encoded
@@ -1090,6 +1091,8 @@ func GenerateConfig(params *GenerateConfigParams) ([]byte, []byte, []byte, []byt
 		capabilities = append(capabilities, protocol.CAPABILITY_UNTUNNELED_WEB_API_REQUESTS)
 	}
 
+	var frontingProviderID string
+
 	for tunnelProtocol := range params.TunnelProtocolPorts {
 
 		capability := protocol.GetCapability(tunnelProtocol)
@@ -1114,6 +1117,10 @@ func GenerateConfig(params *GenerateConfigParams) ([]byte, []byte, []byte, []byt
 			protocol.TunnelProtocolUsesMeek(tunnelProtocol) {
 
 			capabilities = append(capabilities, protocol.GetTacticsCapability(tunnelProtocol))
+		}
+
+		if protocol.TunnelProtocolUsesFrontedMeek(tunnelProtocol) {
+			frontingProviderID = params.FrontingProviderID
 		}
 	}
 
@@ -1165,6 +1172,7 @@ func GenerateConfig(params *GenerateConfigParams) ([]byte, []byte, []byte, []byt
 		Capabilities:                  capabilities,
 		Region:                        "US",
 		ProviderID:                    prng.HexString(8),
+		FrontingProviderID:            frontingProviderID,
 		MeekServerPort:                meekPort,
 		MeekCookieEncryptionPublicKey: meekCookieEncryptionPublicKey,
 		MeekObfuscatedKey:             meekObfuscatedKey,

--- a/psiphon/server/meek_test.go
+++ b/psiphon/server/meek_test.go
@@ -288,7 +288,7 @@ func testMeekResiliency(t *testing.T, spec *transforms.HTTPTransformerParameters
 
 	var serverClientConn atomic.Value
 
-	clientHandler := func(_ string, conn net.Conn) {
+	clientHandler := func(conn net.Conn, _ *additionalTransportData) {
 		serverClientConn.Store(conn)
 		name := "server"
 		relayWaitGroup.Add(1)
@@ -583,7 +583,7 @@ func runTestMeekAccessControl(t *testing.T, rateLimit, restrictProvider, missing
 		isFronted,
 		useObfuscatedSessionTickets,
 		useHTTPNormalizer,
-		func(_ string, conn net.Conn) {
+		func(conn net.Conn, _ *additionalTransportData) {
 			go func() {
 				for {
 					buffer := make([]byte, 1)

--- a/psiphon/server/server_test.go
+++ b/psiphon/server/server_test.go
@@ -44,6 +44,7 @@ import (
 	"syscall"
 	"testing"
 	"time"
+	"unsafe"
 
 	socks "github.com/Psiphon-Labs/goptlib"
 	"github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon"
@@ -57,6 +58,7 @@ import (
 	"github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/tactics"
 	"github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/transforms"
 	"github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/values"
+	lrucache "github.com/cognusion/go-cache-lru"
 	"github.com/miekg/dns"
 	"golang.org/x/net/proxy"
 )
@@ -567,6 +569,21 @@ func TestOmitProvider(t *testing.T) {
 		})
 }
 
+func TestSteeringIP(t *testing.T) {
+	runServer(t,
+		&runServerConfig{
+			tunnelProtocol:       "FRONTED-MEEK-OSSH",
+			enableSSHAPIRequests: true,
+			requireAuthorization: true,
+			doTunneledWebRequest: true,
+			doTunneledNTPRequest: true,
+			forceFragmenting:     true,
+			doDanglingTCPConn:    true,
+			doLogHostProvider:    true,
+			doSteeringIP:         true,
+		})
+}
+
 type runServerConfig struct {
 	tunnelProtocol       string
 	clientTunnelProtocol string
@@ -593,6 +610,7 @@ type runServerConfig struct {
 	doChangeBytesConfig  bool
 	doLogHostProvider    bool
 	inspectFlows         bool
+	doSteeringIP         bool
 }
 
 var (
@@ -602,6 +620,9 @@ var (
 	testCustomHostNameRegex              = `[a-z0-9]{5,10}\.example\.org`
 	testClientFeatures                   = []string{"feature 1", "feature 2"}
 	testDisallowedTrafficAlertActionURLs = []string{"https://example.org/disallowed"}
+
+	// A steering IP must not be a bogon; this address is not dialed.
+	testSteeringIP = "1.1.1.1"
 )
 
 var serverRuns = 0
@@ -709,6 +730,10 @@ func runServer(t *testing.T, runConfig *runServerConfig) {
 	if doServerTactics {
 		generateConfigParams.TacticsRequestPublicKey = tacticsRequestPublicKey
 		generateConfigParams.TacticsRequestObfuscatedKey = tacticsRequestObfuscatedKey
+	}
+
+	if protocol.TunnelProtocolUsesFrontedMeek(runConfig.tunnelProtocol) {
+		generateConfigParams.FrontingProviderID = prng.HexString(8)
 	}
 
 	serverConfigJSON, _, _, _, encodedServerEntry, err := GenerateConfig(generateConfigParams)
@@ -985,7 +1010,8 @@ func runServer(t *testing.T, runConfig *runServerConfig) {
 	// Use a distinct suffix for network ID for each test run to ensure tactics
 	// from different runs don't apply; this is a workaround for the singleton
 	// datastore.
-	jsonNetworkID := fmt.Sprintf(`,"NetworkID" : "WIFI-%s"`, time.Now().String())
+	networkID := fmt.Sprintf("WIFI-%s", time.Now().String())
+	jsonNetworkID := fmt.Sprintf(`,"NetworkID" : "%s"`, networkID)
 
 	jsonLimitTLSProfiles := ""
 	if runConfig.tlsProfile != "" {
@@ -1063,6 +1089,25 @@ func runServer(t *testing.T, runConfig *runServerConfig) {
 		customHostNameProbability := 1.0
 		clientConfig.CustomHostNameProbability = &customHostNameProbability
 		clientConfig.CustomHostNameLimitProtocols = []string{clientTunnelProtocol}
+	}
+
+	if runConfig.doSteeringIP {
+
+		if runConfig.tunnelProtocol != protocol.TUNNEL_PROTOCOL_FRONTED_MEEK {
+			t.Fatalf("steering IP test requires FRONTED-MEEK-OSSH")
+		}
+
+		protocol.SetFrontedMeekHTTPDialPortNumber(psiphonServerPort)
+
+		// Note that in an actual fronting deployment, the steering IP header
+		// is added to the HTTP request by the CDN and any ingress steering
+		// IP header would be stripped to avoid spoofing. To facilitate this
+		// test case, we just have the client add the steering IP header as
+		// if it were the CDN.
+
+		headers := make(http.Header)
+		headers.Set("X-Psiphon-Steering-Ip", testSteeringIP)
+		clientConfig.MeekAdditionalHeaders = headers
 	}
 
 	err = clientConfig.Commit(false)
@@ -1592,6 +1637,35 @@ func runServer(t *testing.T, runConfig *runServerConfig) {
 			}
 		}
 	}
+
+	if runConfig.doSteeringIP {
+
+		// Access the unexported controller.steeringIPCache
+		controllerStruct := reflect.ValueOf(controller).Elem()
+		steeringIPCacheField := controllerStruct.Field(40)
+		steeringIPCacheField = reflect.NewAt(
+			steeringIPCacheField.Type(), unsafe.Pointer(steeringIPCacheField.UnsafeAddr())).Elem()
+		steeringIPCache := steeringIPCacheField.Interface().(*lrucache.Cache)
+
+		if steeringIPCache.ItemCount() != 1 {
+			t.Fatalf("unexpected steering IP cache size: %d", steeringIPCache.ItemCount())
+		}
+
+		key := fmt.Sprintf(
+			"%s %s %s",
+			networkID,
+			generateConfigParams.FrontingProviderID,
+			runConfig.tunnelProtocol)
+
+		entry, ok := steeringIPCache.Get(key)
+		if !ok {
+			t.Fatalf("no entry for steering IP cache key: %s", key)
+		}
+
+		if entry.(string) != testSteeringIP {
+			t.Fatalf("unexpected cached steering IP: %v", entry)
+		}
+	}
 }
 
 func sendNotificationReceived(c chan<- struct{}) {
@@ -1849,12 +1923,14 @@ func checkExpectedServerTunnelLogFields(
 			return fmt.Errorf("unexpected meek_host_header '%s'", fields["meek_host_header"])
 		}
 
-		for _, name := range []string{
-			"meek_dial_ip_address",
-			"meek_resolved_ip_address",
-		} {
-			if fields[name] != nil {
-				return fmt.Errorf("unexpected field '%s'", name)
+		if !protocol.TunnelProtocolUsesFrontedMeek(runConfig.tunnelProtocol) {
+			for _, name := range []string{
+				"meek_dial_ip_address",
+				"meek_resolved_ip_address",
+			} {
+				if fields[name] != nil {
+					return fmt.Errorf("unexpected field '%s'", name)
+				}
 			}
 		}
 	}
@@ -1876,13 +1952,15 @@ func checkExpectedServerTunnelLogFields(
 			return fmt.Errorf("unexpected meek_sni_server_name '%s'", fields["meek_sni_server_name"])
 		}
 
-		for _, name := range []string{
-			"meek_dial_ip_address",
-			"meek_resolved_ip_address",
-			"meek_host_header",
-		} {
-			if fields[name] != nil {
-				return fmt.Errorf("unexpected field '%s'", name)
+		if !protocol.TunnelProtocolUsesFrontedMeek(runConfig.tunnelProtocol) {
+			for _, name := range []string{
+				"meek_dial_ip_address",
+				"meek_resolved_ip_address",
+				"meek_host_header",
+			} {
+				if fields[name] != nil {
+					return fmt.Errorf("unexpected field '%s'", name)
+				}
 			}
 		}
 
@@ -2121,6 +2199,20 @@ func checkExpectedServerTunnelLogFields(
 		}
 	} else {
 		name := "provider"
+		if fields[name] != nil {
+			return fmt.Errorf("unexpected field '%s'", name)
+		}
+	}
+
+	if runConfig.doSteeringIP {
+		name := "relayed_steering_ip"
+		if fields[name] == nil {
+			return fmt.Errorf("missing expected field '%s'", name)
+		}
+		if fields[name] != testSteeringIP {
+			return fmt.Errorf("unexpected field value %s: %v != %v", name, fields[name], testSteeringIP)
+		}
+		name = "steering_ip"
 		if fields[name] != nil {
 			return fmt.Errorf("unexpected field '%s'", name)
 		}
@@ -3055,6 +3147,7 @@ func storePruneServerEntriesTest(
 
 		dialParams, err := psiphon.MakeDialParameters(
 			clientConfig,
+			nil,
 			nil,
 			func(_ *protocol.ServerEntry, _ string) bool { return true },
 			func(serverEntry *protocol.ServerEntry) (string, bool) {

--- a/psiphon/server/sessionID_test.go
+++ b/psiphon/server/sessionID_test.go
@@ -167,6 +167,7 @@ func TestDuplicateSessionID(t *testing.T) {
 		dialParams, err := psiphon.MakeDialParameters(
 			clientConfig,
 			nil,
+			nil,
 			func(_ *protocol.ServerEntry, _ string) bool { return false },
 			func(_ *protocol.ServerEntry) (string, bool) { return "OSSH", true },
 			serverEntry,

--- a/psiphon/tactics.go
+++ b/psiphon/tactics.go
@@ -73,12 +73,12 @@ func GetTactics(ctx context.Context, config *Config) {
 		return
 	}
 
-	// If the context is already Done, don't even start the request.
-	if ctx.Err() != nil {
-		return
-	}
-
 	if tacticsRecord == nil {
+
+		// If the context is already Done, don't even start the request.
+		if ctx.Err() != nil {
+			return
+		}
 
 		iterator, err := NewTacticsServerEntryIterator(config)
 		if err != nil {
@@ -216,6 +216,7 @@ func fetchTactics(
 
 	dialParams, err := MakeDialParameters(
 		config,
+		nil,
 		nil,
 		canReplay,
 		selectProtocol,


### PR DESCRIPTION
In addition, this commit:

- Adds support for running test FRONTED-MEEK-OSSH servers on ports other than 443

- Adds support for adding arbitrary HTTP headers to HTTPS requests

- Fixes the "already done" context case in GetTactics, which failed to apply local tactics

- Switches the meek rate limiter to use the unspoofable listener tunnel protocol