### PR TITLE
Discovery fixes

### DIFF
--- a/psiphon/server/discovery.go
+++ b/psiphon/server/discovery.go
@@ -110,8 +110,6 @@ func (d *Discovery) reload(reloadedTactics bool) error {
 	// Initialize and set underlying discovery component. Replaces old
 	// component if discovery is already initialized.
 
-	oldDiscovery := d.discovery
-
 	discovery := discovery.MakeDiscovery(
 		d.support.PsinetDatabase.GetDiscoveryServers(),
 		discoveryStrategy)
@@ -120,6 +118,7 @@ func (d *Discovery) reload(reloadedTactics bool) error {
 
 	d.Lock()
 
+	oldDiscovery := d.discovery
 	d.discovery = discovery
 	d.currentStrategy = strategy
 
@@ -143,6 +142,8 @@ func (d *Discovery) reload(reloadedTactics bool) error {
 
 // Stop stops discovery and cleans up underlying resources.
 func (d *Discovery) Stop() {
+	d.Lock()
+	defer d.Unlock()
 	d.discovery.Stop()
 }
 

--- a/psiphon/server/discovery/discovery.go
+++ b/psiphon/server/discovery/discovery.go
@@ -167,7 +167,8 @@ func (d *Discovery) Start() {
 			// Note: servers with a discovery date range in the past are not
 			// removed from d.all in case the wall clock has drifted;
 			// otherwise, we risk removing them prematurely.
-			servers, nextUpdate := discoverableServers(d.all, d.clk)
+			var servers []*psinet.DiscoveryServer
+			servers, nextUpdate = discoverableServers(d.all, d.clk)
 
 			// Update the set of discoverable servers.
 			d.strategy.serversChanged(servers)

--- a/psiphon/server/discovery/discovery_test.go
+++ b/psiphon/server/discovery/discovery_test.go
@@ -149,9 +149,9 @@ func runDiscoveryTest(tt *discoveryTest, now time.Time) error {
 	discovery.Start()
 
 	for _, check := range tt.checks {
-		time.Sleep(1 * time.Second) // let async code complete
+		time.Sleep(10 * time.Millisecond) // let async code complete
 		clk.SetNow(check.t)
-		time.Sleep(1 * time.Second) // let async code complete
+		time.Sleep(10 * time.Millisecond) // let async code complete
 		discovered := discovery.SelectServers(net.IP{})
 		discoveredIPs := make([]string, len(discovered))
 		for i := range discovered {


### PR DESCRIPTION
- Fix: shadowing nextUpdate causes NewTimer to fire instantly on each loop iteration
- Fix: race conditions
- Reduce TestDiscoveryTestClock runtime