### PR TITLE
Bug fixes

### DIFF
--- a/psiphon/common/authPackage.go
+++ b/psiphon/common/authPackage.go
@@ -408,7 +408,11 @@ func (streamer *limitedJSONStreamer) Stream() error {
 
 			case stateJSONSeekingStringValueStart:
 				if b == '"' {
-					state = stateJSONSeekingStringValueEnd
+
+					// Note: this assignment is flagged by github.com/gordonklaus/ineffassign,
+					// but is technically the correct state.
+					//
+					//state = stateJSONSeekingStringValueEnd
 
 					key := keyBuffer.String()
 

--- a/psiphon/common/inproxy/client.go
+++ b/psiphon/common/inproxy/client.go
@@ -44,7 +44,6 @@ const (
 // initial dial address.
 type ClientConn struct {
 	config       *ClientConfig
-	brokerClient *BrokerClient
 	webRTCConn   *webRTCConn
 	connectionID ID
 	remoteAddr   net.Addr

--- a/psiphon/common/inproxy/inproxy_test.go
+++ b/psiphon/common/inproxy/inproxy_test.go
@@ -535,7 +535,6 @@ func runTestInproxy(doMustUpgrade bool) error {
 					DialAddress:                  addr,
 					PackedDestinationServerEntry: packedDestinationServerEntry,
 					MustUpgrade: func() {
-						fmt.Printf("HI!\n")
 						close(receivedClientMustUpgrade)
 						cancelDial()
 					},

--- a/psiphon/common/inproxy/session_test.go
+++ b/psiphon/common/inproxy/session_test.go
@@ -347,7 +347,7 @@ func runTestSessions() error {
 
 	request = roundTripper.MakeRequest()
 
-	response, err = unknownInitiatorSessions.RoundTrip(
+	_, err = unknownInitiatorSessions.RoundTrip(
 		ctx,
 		roundTripper,
 		responderPublicKey,
@@ -674,7 +674,6 @@ func runTestNoise() error {
 		return errors.Trace(err)
 	}
 
-	receivedPayload = nil
 	receivedPayload, _, _, err = initiatorHandshake.ReadMessage(nil, responderMsg)
 	if err != nil {
 		return errors.Trace(err)

--- a/psiphon/common/parameters/parameters.go
+++ b/psiphon/common/parameters/parameters.go
@@ -1687,7 +1687,10 @@ func (p ParametersAccessor) IsNil() bool {
 // where memory footprint is a concern, and where the ParametersAccessor is
 // not immediately going out of scope. After Close is called, all other
 // ParametersAccessor functions will panic if called.
-func (p ParametersAccessor) Close() {
+//
+// Limitation: since ParametersAccessor is typically passed by value, this
+// Close call only impacts the immediate copy.
+func (p *ParametersAccessor) Close() {
 	p.snapshot = nil
 }
 

--- a/psiphon/common/prng/prng.go
+++ b/psiphon/common/prng/prng.go
@@ -198,7 +198,7 @@ func (p *PRNG) Int63() int64 {
 // Uint64 is equivilent to math/rand.Uint64.
 func (p *PRNG) Uint64() uint64 {
 	var b [8]byte
-	p.Read(b[:])
+	_, _ = p.Read(b[:])
 	return binary.BigEndian.Uint64(b[:])
 }
 
@@ -300,7 +300,7 @@ func (p *PRNG) RangeUint32(min, max uint32) uint32 {
 // Bytes returns a new slice containing length random bytes.
 func (p *PRNG) Bytes(length int) []byte {
 	b := make([]byte, length)
-	p.Read(b)
+	_, _ = p.Read(b)
 	return b
 }
 

--- a/psiphon/common/resolver/resolver.go
+++ b/psiphon/common/resolver/resolver.go
@@ -1523,7 +1523,10 @@ func performDNSQuery(
 	startTime := time.Now()
 
 	// Send the DNS request
-	dnsConn.WriteMsg(request)
+	err := dnsConn.WriteMsg(request)
+	if err != nil {
+		return nil, nil, -1, errors.Trace(err)
+	}
 
 	// Read and process the DNS response
 	var IPs []net.IP

--- a/psiphon/common/resolver/resolver_test.go
+++ b/psiphon/common/resolver/resolver_test.go
@@ -647,7 +647,7 @@ func runTestResolver() error {
 
 	cancelFunc()
 
-	IPs, err = resolver.ResolveIP(ctx, networkID, params, exampleDomain)
+	_, err = resolver.ResolveIP(ctx, networkID, params, exampleDomain)
 	if err == nil {
 		return errors.TraceNew("unexpected success")
 	}

--- a/psiphon/common/utils.go
+++ b/psiphon/common/utils.go
@@ -136,8 +136,8 @@ func TruncateTimestampToHour(timestamp string) string {
 func Compress(data []byte) []byte {
 	var compressedData bytes.Buffer
 	writer := zlib.NewWriter(&compressedData)
-	writer.Write(data)
-	writer.Close()
+	_, _ = writer.Write(data)
+	_ = writer.Close()
 	return compressedData.Bytes()
 }
 

--- a/psiphon/inproxy.go
+++ b/psiphon/inproxy.go
@@ -1074,11 +1074,9 @@ func MakeInproxyBrokerDialParameters(
 
 	currentTimestamp := time.Now()
 
-	var brokerDialParams *InproxyBrokerDialParameters
-
 	// Select new broker dial parameters
 
-	brokerDialParams = &InproxyBrokerDialParameters{
+	brokerDialParams := &InproxyBrokerDialParameters{
 		brokerSpec:             brokerSpec,
 		LastUsedTimestamp:      currentTimestamp,
 		LastUsedBrokerSpecHash: hashBrokerSpec(brokerSpec),
@@ -2315,13 +2313,6 @@ func newInproxyUDPConn(ctx context.Context, config *Config) (net.PacketConn, err
 	}
 
 	return conn, nil
-}
-
-func inproxyUDPAddrFromAddrPort(addrPort netip.AddrPort) *net.UDPAddr {
-	return &net.UDPAddr{
-		IP:   addrPort.Addr().AsSlice(),
-		Port: int(addrPort.Port()),
-	}
 }
 
 func (conn *inproxyUDPConn) ReadFrom(p []byte) (int, net.Addr, error) {

--- a/psiphon/remoteServerList.go
+++ b/psiphon/remoteServerList.go
@@ -167,7 +167,11 @@ func FetchObfuscatedServerLists(
 	// the registry, so clear the ETag to ensure that always happens.
 	_, err := os.Stat(cachedFilename)
 	if os.IsNotExist(err) {
-		SetUrlETag(canonicalURL, "")
+		err := SetUrlETag(canonicalURL, "")
+		if err != nil {
+			NoticeWarning("SetUrlETag failed: %v", errors.Trace(err))
+			// Continue
+		}
 	}
 
 	// failed is set if any operation fails and should trigger a retry. When the OSL registry

--- a/psiphon/server/api.go
+++ b/psiphon/server/api.go
@@ -1788,7 +1788,7 @@ func isGeoHashString(_ *Config, value string) bool {
 		return false
 	}
 	for _, c := range value {
-		if strings.Index(geohashAlphabet, string(c)) == -1 {
+		if !strings.Contains(geohashAlphabet, string(c)) {
 			return false
 		}
 	}

--- a/psiphon/server/meek.go
+++ b/psiphon/server/meek.go
@@ -1838,7 +1838,10 @@ func (server *MeekServer) inproxyReloadTactics() error {
 		return errors.Trace(err)
 	}
 
-	server.inproxyBroker.SetCommonCompartmentIDs(commonCompartmentIDs)
+	err = server.inproxyBroker.SetCommonCompartmentIDs(commonCompartmentIDs)
+	if err != nil {
+		return errors.Trace(err)
+	}
 
 	server.inproxyBroker.SetTimeouts(
 		p.Duration(parameters.InproxyBrokerProxyAnnounceTimeout),

--- a/psiphon/server/replay.go
+++ b/psiphon/server/replay.go
@@ -229,7 +229,7 @@ func (r *ReplayCache) SetReplayParameters(
 	r.cacheMutex.Lock()
 	defer r.cacheMutex.Unlock()
 
-	r.cache.Add(key, value, TTL)
+	r.cache.Set(key, value, TTL)
 
 	// go-cache-lru is typically safe for concurrent access but explicit
 	// synchronization is required when accessing Items. Items may include

--- a/psiphon/server/server_test.go
+++ b/psiphon/server/server_test.go
@@ -1965,7 +1965,7 @@ func runServer(t *testing.T, runConfig *runServerConfig) {
 
 		// Access the unexported controller.steeringIPCache
 		controllerStruct := reflect.ValueOf(controller).Elem()
-		steeringIPCacheField := controllerStruct.Field(40)
+		steeringIPCacheField := controllerStruct.FieldByName("steeringIPCache")
 		steeringIPCacheField = reflect.NewAt(
 			steeringIPCacheField.Type(), unsafe.Pointer(steeringIPCacheField.UnsafeAddr())).Elem()
 		steeringIPCache := steeringIPCacheField.Interface().(*lrucache.Cache)

--- a/psiphon/server/tunnelServer.go
+++ b/psiphon/server/tunnelServer.go
@@ -1455,8 +1455,10 @@ func (sshServer *sshServer) reloadTactics() error {
 			// for broker public keys no longer in the known/expected list;
 			// but will retain any existing sessions for broker public keys
 			// that remain in the list.
-			sshServer.inproxyBrokerSessions.SetKnownBrokerPublicKeys(brokerPublicKeys)
-
+			err = sshServer.inproxyBrokerSessions.SetKnownBrokerPublicKeys(brokerPublicKeys)
+			if err != nil {
+				return errors.Trace(err)
+			}
 		}
 	}
 
@@ -1553,7 +1555,7 @@ func (sshServer *sshServer) handleClient(
 					conn.Close()
 				})
 			}
-			io.Copy(ioutil.Discard, conn)
+			_, _ = io.Copy(ioutil.Discard, conn)
 			conn.Close()
 			afterFunc.Stop()
 
@@ -2316,7 +2318,8 @@ func (sshClient *sshClient) run(
 			// It is recommended to set ServerOSSHPrefixSpecs, etc., in default
 			// tactics.
 
-			p, err := sshClient.sshServer.support.ServerTacticsParametersCache.Get(sshClient.peerGeoIPData)
+			var p parameters.ParametersAccessor
+			p, err = sshClient.sshServer.support.ServerTacticsParametersCache.Get(sshClient.peerGeoIPData)
 
 			// Log error, but continue. A default prefix spec will be used by the server.
 			if err != nil {
@@ -2655,8 +2658,8 @@ func (sshClient *sshClient) authLogCallback(conn ssh.ConnMetadata, method string
 // I/O, as newly connecting clients need to await stop completion of any
 // existing connection that shares the same session ID.
 func (sshClient *sshClient) stop() {
-	sshClient.sshConn.Close()
-	sshClient.sshConn.Wait()
+	_ = sshClient.sshConn.Close()
+	_ = sshClient.sshConn.Wait()
 }
 
 // awaitStopped will block until sshClient.run has exited, at which point all
@@ -3677,7 +3680,7 @@ func (sshClient *sshClient) rejectNewChannel(newChannel ssh.NewChannel, logMessa
 	}
 
 	// Note: logMessage is internal, for logging only; just the reject reason is sent to the client.
-	newChannel.Reject(reason, reason.String())
+	_ = newChannel.Reject(reason, reason.String())
 }
 
 // setHandshakeState sets the handshake state -- that it completed and
@@ -4783,7 +4786,7 @@ func (sshClient *sshClient) handleTCPChannel(
 				return
 			}
 
-			newChannel.Reject(protocol.CHANNEL_REJECT_REASON_SPLIT_TUNNEL, "")
+			_ = newChannel.Reject(protocol.CHANNEL_REJECT_REASON_SPLIT_TUNNEL, "")
 			return
 		}
 	}

--- a/psiphon/serverApi.go
+++ b/psiphon/serverApi.go
@@ -1459,7 +1459,7 @@ func HandleOSLRequest(
 
 	defer func() {
 		if retErr != nil {
-			request.Reply(false, nil)
+			_ = request.Reply(false, nil)
 		}
 	}()
 
@@ -1470,7 +1470,11 @@ func HandleOSLRequest(
 	}
 
 	if oslRequest.ClearLocalSLOKs {
-		DeleteSLOKs()
+		err := DeleteSLOKs()
+		if err != nil {
+			NoticeWarning("DeleteSLOKs failed: %v", errors.Trace(err))
+			// Continue
+		}
 	}
 
 	seededNewSLOK := false
@@ -1479,7 +1483,7 @@ func HandleOSLRequest(
 		duplicate, err := SetSLOK(slok.ID, slok.Key)
 		if err != nil {
 			// TODO: return error to trigger retry?
-			NoticeWarning("SetSLOK failed: %s", errors.Trace(err))
+			NoticeWarning("SetSLOK failed: %v", errors.Trace(err))
 		} else if !duplicate {
 			seededNewSLOK = true
 		}
@@ -1493,7 +1497,10 @@ func HandleOSLRequest(
 		tunnelOwner.SignalSeededNewSLOK()
 	}
 
-	request.Reply(true, nil)
+	err = request.Reply(true, nil)
+	if err != nil {
+		return errors.Trace(err)
+	}
 
 	return nil
 }
@@ -1503,7 +1510,7 @@ func HandleAlertRequest(
 
 	defer func() {
 		if retErr != nil {
-			request.Reply(false, nil)
+			_ = request.Reply(false, nil)
 		}
 	}()
 
@@ -1517,7 +1524,10 @@ func HandleAlertRequest(
 		NoticeServerAlert(alertRequest)
 	}
 
-	request.Reply(true, nil)
+	err = request.Reply(true, nil)
+	if err != nil {
+		return errors.Trace(err)
+	}
 
 	return nil
 }

--- a/psiphon/tactics.go
+++ b/psiphon/tactics.go
@@ -79,7 +79,7 @@ func GetTactics(ctx context.Context, config *Config, useStoredTactics bool) (fet
 			GetTacticsStorer(config),
 			config.GetNetworkID())
 		if err != nil {
-			NoticeWarning("get stored tactics failed: %s", err)
+			NoticeWarning("get stored tactics failed: %s", errors.Trace(err))
 
 			// The error will be due to a local datastore problem.
 			// While we could proceed with the tactics request, this
@@ -97,7 +97,7 @@ func GetTactics(ctx context.Context, config *Config, useStoredTactics bool) (fet
 
 		iterator, err := NewTacticsServerEntryIterator(config)
 		if err != nil {
-			NoticeWarning("tactics iterator failed: %s", err)
+			NoticeWarning("tactics iterator failed: %s", errors.Trace(err))
 			return
 		}
 		defer iterator.Close()
@@ -113,7 +113,7 @@ func GetTactics(ctx context.Context, config *Config, useStoredTactics bool) (fet
 
 			serverEntry, err := iterator.Next()
 			if err != nil {
-				NoticeWarning("tactics iterator failed: %s", err)
+				NoticeWarning("tactics iterator failed: %s", errors.Trace(err))
 				return
 			}
 
@@ -126,7 +126,11 @@ func GetTactics(ctx context.Context, config *Config, useStoredTactics bool) (fet
 					return
 				}
 
-				iterator.Reset()
+				err := iterator.Reset()
+				if err != nil {
+					NoticeWarning("tactics iterator failed: %s", errors.Trace(err))
+					return
+				}
 				continue
 			}
 
@@ -159,7 +163,7 @@ func GetTactics(ctx context.Context, config *Config, useStoredTactics bool) (fet
 				}
 			}
 
-			NoticeWarning("tactics request failed: %s", err)
+			NoticeWarning("tactics request failed: %s", errors.Trace(err))
 
 			// On error, proceed with a retry, as the error is likely
 			// due to a network failure.
@@ -190,7 +194,7 @@ func GetTactics(ctx context.Context, config *Config, useStoredTactics bool) (fet
 		err := config.SetParameters(
 			tacticsRecord.Tag, true, tacticsRecord.Tactics.Parameters)
 		if err != nil {
-			NoticeWarning("apply tactics failed: %s", err)
+			NoticeWarning("apply tactics failed: %s", errors.Trace(err))
 
 			// The error will be due to invalid tactics values from
 			// the server. When SetParameters fails, all
@@ -258,7 +262,7 @@ func fetchTactics(
 		return nil, errors.Tracef(
 			"failed to make dial parameters for %s: %v",
 			serverEntry.GetDiagnosticID(),
-			err)
+			errors.Trace(err))
 	}
 
 	NoticeRequestingTactics(dialParams)


### PR DESCRIPTION
Flagged by golangci-lint/ineffassign.

- Bug: client broker packet relay only relayed one packet

- Bug: packetman randomized TCP flag transform not properly applied

- Bug: ParametersAccessor.Close had no effect

- Avoid allocation in udpgwPortForward.relayDownstream buffer pool

- Add/fix error return checks

- Remove some unused code