### PR TITLE
Add NetworkChanged

### DIFF
--- a/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
+++ b/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
@@ -208,7 +208,9 @@ public class PsiphonTunnel {
             @Override
             public void onChanged() {
                 try {
-                    reconnectPsiphon();
+                    // networkChanged initiates a reset of all open network
+                    // connections, including a tunnel reconnect.
+                    Psi.networkChanged();
                 } catch (Exception e) {
                     mHostService.onDiagnosticMessage("reconnect error: " + e);
                 }

--- a/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel/PsiphonTunnel.m
+++ b/MobileLibrary/iOS/PsiphonTunnel/PsiphonTunnel/PsiphonTunnel.m
@@ -1549,11 +1549,14 @@ typedef NS_ERROR_ENUM(PsiphonTunnelErrorDomain, PsiphonTunnelErrorCode) {
 
         previousNetworkStatus = atomic_exchange(&self->currentNetworkStatus, networkStatus);
 
-        // Restart if the network status or interface has changed, unless the previous status was
-        // NetworkReachabilityNotReachable, because the tunnel should be waiting for connectivity in
-        // that case.
+        // Signal when the network status or interface has changed, unless the
+        // previous status was NetworkReachabilityNotReachable, because the
+        // tunnel should be waiting for connectivity in that case.
+        //
+        // GoPsiNetworkChanged initiates a reset of all open network
+        // connections, including a tunnel reconnect.
         if ((networkStatus != previousNetworkStatus || interfaceChanged) && previousNetworkStatus != NetworkReachabilityNotReachable) {
-            GoPsiReconnectTunnel();
+            GoPsiNetworkChanged();
         }
     }
 }

--- a/MobileLibrary/psi/psi.go
+++ b/MobileLibrary/psi/psi.go
@@ -280,6 +280,18 @@ func ReconnectTunnel() {
 	}
 }
 
+// NetworkChanged initiates a reset of all open network connections, including
+// a tunnel reconnect.
+func NetworkChanged() {
+
+	controllerMutex.Lock()
+	defer controllerMutex.Unlock()
+
+	if controller != nil {
+		controller.NetworkChanged()
+	}
+}
+
 // SetDynamicConfig overrides the sponsor ID and authorizations fields set in
 // the config passed to Start. SetDynamicConfig has no effect if no Controller
 // is started.

--- a/psiphon/common/inproxy/inproxy_test.go
+++ b/psiphon/common/inproxy/inproxy_test.go
@@ -91,6 +91,9 @@ func runTestInproxy(doMustUpgrade bool) error {
 	testNewTacticsTag := "new-tactics-tag"
 	testUnchangedTacticsPayload := []byte(prng.HexString(100))
 
+	currentNetworkCtx, currentNetworkCancelFunc := context.WithCancel(context.Background())
+	defer currentNetworkCancelFunc()
+
 	// TODO: test port mapping
 
 	stunServerAddressSucceededCount := int32(0)
@@ -429,6 +432,10 @@ func runTestInproxy(doMustUpgrade bool) error {
 
 			WaitForNetworkConnectivity: func() bool {
 				return true
+			},
+
+			GetCurrentNetworkContext: func() context.Context {
+				return currentNetworkCtx
 			},
 
 			GetBrokerClient: func() (*BrokerClient, error) {

--- a/psiphon/controller.go
+++ b/psiphon/controller.go
@@ -461,8 +461,12 @@ func (controller *Controller) SetDynamicConfig(sponsorID string, authorizations 
 // proxy connections.
 func (controller *Controller) NetworkChanged() {
 
-	// Tunnels don't yet use the current network context.
+	// Explicitly reset components that don't use the current network context.
 	controller.TerminateNextActiveTunnel()
+	if controller.inproxyProxyBrokerClientManager != nil {
+		controller.inproxyProxyBrokerClientManager.NetworkChanged()
+	}
+	controller.inproxyClientBrokerClientManager.NetworkChanged()
 
 	controller.currentNetworkMutex.Lock()
 	defer controller.currentNetworkMutex.Unlock()

--- a/psiphon/controller.go
+++ b/psiphon/controller.go
@@ -101,6 +101,10 @@ type Controller struct {
 	inproxyLastStoredTactics                time.Time
 	establishSignalForceTacticsFetch        chan struct{}
 	inproxyClientDialRateLimiter            *rate.Limiter
+
+	currentNetworkMutex      sync.Mutex
+	currentNetworkCtx        context.Context
+	currentNetworkCancelFunc context.CancelFunc
 }
 
 // NewController initializes a new controller.
@@ -176,6 +180,18 @@ func NewController(config *Config) (controller *Controller, err error) {
 		tlsClientSessionCache:     utls.NewLRUClientSessionCache(0),
 		quicTLSClientSessionCache: tls.NewLRUClientSessionCache(0),
 	}
+
+	// Initialize the current network context. This context represents the
+	// lifetime of the host's current active network interface. When
+	// Controller.NetworkChanged is called (by the Android and iOS platform
+	// code), the previous current network interface is considered to be no
+	// longer active and the corresponding current network context is canceled.
+	// Components may use currentNetworkCtx to cancel and close old network
+	// connections and quickly initiate new connections when the active
+	// interface changes.
+
+	controller.currentNetworkCtx, controller.currentNetworkCancelFunc =
+		context.WithCancel(context.Background())
 
 	// Initialize untunneledDialConfig, used by untunneled dials including
 	// remote server list and upgrade downloads.
@@ -411,6 +427,9 @@ func (controller *Controller) Run(ctx context.Context) {
 		controller.packetTunnelClient.Stop()
 	}
 
+	// Cleanup current network context
+	controller.currentNetworkCancelFunc()
+
 	// All workers -- runTunnels, establishment workers, and auxilliary
 	// workers such as fetch remote server list and untunneled uprade
 	// download -- operate with the controller run context and will all
@@ -435,6 +454,33 @@ func (controller *Controller) SignalComponentFailure() {
 // next tunnel connection.
 func (controller *Controller) SetDynamicConfig(sponsorID string, authorizations []string) {
 	controller.config.SetDynamicConfig(sponsorID, authorizations)
+}
+
+// NetworkChanged initiates a reset of all open network connections, including
+// a tunnel reconnect, if one is running, as well as terminating any in-proxy
+// proxy connections.
+func (controller *Controller) NetworkChanged() {
+
+	// Tunnels don't yet use the current network context.
+	controller.TerminateNextActiveTunnel()
+
+	controller.currentNetworkMutex.Lock()
+	defer controller.currentNetworkMutex.Unlock()
+
+	// Cancel the previous current network context, which will interrupt any
+	// operations using this context.
+	controller.currentNetworkCancelFunc()
+
+	// Create a new context for the new current network.
+	controller.currentNetworkCtx, controller.currentNetworkCancelFunc =
+		context.WithCancel(context.Background())
+}
+
+func (controller *Controller) getCurrentNetworkContext() context.Context {
+	controller.currentNetworkMutex.Lock()
+	defer controller.currentNetworkMutex.Unlock()
+
+	return controller.currentNetworkCtx
 }
 
 // TerminateNextActiveTunnel terminates the active tunnel, which will initiate
@@ -2936,6 +2982,7 @@ func (controller *Controller) runInproxyProxy() {
 		Logger:                        NoticeCommonLogger(debugLogging),
 		EnableWebRTCDebugLogging:      debugLogging,
 		WaitForNetworkConnectivity:    controller.inproxyWaitForNetworkConnectivity,
+		GetCurrentNetworkContext:      controller.getCurrentNetworkContext,
 		GetBrokerClient:               controller.inproxyGetProxyBrokerClient,
 		GetBaseAPIParameters:          controller.inproxyGetProxyAPIParameters,
 		MakeWebRTCDialCoordinator:     controller.inproxyMakeProxyWebRTCDialCoordinator,


### PR DESCRIPTION
- Generalize network change signalling for cases beyond reconnecting the current tunnel.

- Terminate in-proxy proxy connections on network change, for faster re-announce turn around time on a new network.