### PR TITLE
Use Psiphon-Labs/utls@b18909f

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/Psiphon-Labs/goptlib v0.0.0-20200406165125-c0e32a7a3464
 	github.com/Psiphon-Labs/psiphon-tls v0.0.0-20240824224428-ca6969e315a9
 	github.com/Psiphon-Labs/quic-go v0.0.0-20240821052333-b6316b594e39
-	github.com/Psiphon-Labs/utls v1.1.1-0.20240821052800-443a34df921f
+	github.com/Psiphon-Labs/utls v1.1.1-0.20241107183331-b18909f8ccaa
 	github.com/armon/go-proxyproto v0.0.0-20180202201750-5b7edb60ff5f
 	github.com/bifurcation/mint v0.0.0-20180306135233-198357931e61
 	github.com/bits-and-blooms/bloom/v3 v3.6.0

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/Psiphon-Labs/psiphon-tls v0.0.0-20240824224428-ca6969e315a9 h1:AJj1cS
 github.com/Psiphon-Labs/psiphon-tls v0.0.0-20240824224428-ca6969e315a9/go.mod h1:AaKKoshr8RI1LZTheeNDtNuZ39qNVPWVK4uir2c2XIs=
 github.com/Psiphon-Labs/quic-go v0.0.0-20240821052333-b6316b594e39 h1:ft0K9EDdBtMl+Q/akZ+qt3SdcmbtnTQOgE3OlWI6uz0=
 github.com/Psiphon-Labs/quic-go v0.0.0-20240821052333-b6316b594e39/go.mod h1:2MTiPsgoOqWs3Bo6Xr3ElMBX6zzfjd3YkDFpQJLwHdQ=
-github.com/Psiphon-Labs/utls v1.1.1-0.20240821052800-443a34df921f h1:7pxNVyg1fYHhJGoZjlDVXYIEeEbihNPv7fUgmKw3MG4=
-github.com/Psiphon-Labs/utls v1.1.1-0.20240821052800-443a34df921f/go.mod h1:dxmztdV9lf59cq44YY8r21m3b+xSjhg98cgZW8WK1p0=
+github.com/Psiphon-Labs/utls v1.1.1-0.20241107183331-b18909f8ccaa h1:5FszHIhxb7yO267qt47tTfJOtD31k7R80L88EwNm4tc=
+github.com/Psiphon-Labs/utls v1.1.1-0.20241107183331-b18909f8ccaa/go.mod h1:dxmztdV9lf59cq44YY8r21m3b+xSjhg98cgZW8WK1p0=
 github.com/alexbrainman/sspi v0.0.0-20231016080023-1a75b4708caa h1:LHTHcTQiSGT7VVbI0o4wBRNQIgn917usHWOd6VAffYI=
 github.com/alexbrainman/sspi v0.0.0-20231016080023-1a75b4708caa/go.mod h1:cEWa1LVoE5KvSD9ONXsZrj0z6KqySlCCNKHlLzbqAt4=
 github.com/andybalholm/brotli v1.0.6 h1:Yf9fFpf49Zrxb9NlQaluyE92/+X7UVHlhMNJN2sxfOI=

--- a/vendor/github.com/Psiphon-Labs/utls/u_parrots.go
+++ b/vendor/github.com/Psiphon-Labs/utls/u_parrots.go
@@ -2636,7 +2636,12 @@ func (uconn *UConn) ApplyPreset(p *ClientHelloSpec) error {
 	} else if kemKey, ok := clientKeySharePrivate.(*kemPrivateKey); ok {
 		uconn.HandshakeState.State13.KEMKey = kemKey.ToPublic()
 	}
-	uconn.HandshakeState.State13.KeySharesParams = NewKeySharesParameters()
+
+	// [Psiphon]
+	if uconn.HandshakeState.State13.KeySharesParams == nil {
+		uconn.HandshakeState.State13.KeySharesParams = NewKeySharesParameters()
+	}
+
 	hello := uconn.HandshakeState.Hello
 
 	switch len(hello.Random) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -44,7 +44,7 @@ github.com/Psiphon-Labs/quic-go/internal/utils/ringbuffer
 github.com/Psiphon-Labs/quic-go/internal/wire
 github.com/Psiphon-Labs/quic-go/logging
 github.com/Psiphon-Labs/quic-go/quicvarint
-# github.com/Psiphon-Labs/utls v1.1.1-0.20240821052800-443a34df921f
+# github.com/Psiphon-Labs/utls v1.1.1-0.20241107183331-b18909f8ccaa
 ## explicit; go 1.21
 github.com/Psiphon-Labs/utls
 github.com/Psiphon-Labs/utls/dicttls


### PR DESCRIPTION
* Fixes an issue where servers that selected a key_share other than X25519 would cause TLS handshake to fail.