### PR TITLE
Integrate common/networkid

### DIFF
--- a/psiphon/common/parameters/parameters.go
+++ b/psiphon/common/parameters/parameters.go
@@ -477,6 +477,7 @@ const (
 	InproxyProxyOnBrokerClientFailedRetryPeriod        = "InproxyProxyOnBrokerClientFailedRetryPeriod"
 	InproxyProxyIncompatibleNetworkTypes               = "InproxyProxyIncompatibleNetworkTypes"
 	InproxyClientIncompatibleNetworkTypes              = "InproxyClientIncompatibleNetworkTypes"
+	NetworkIDCacheTTL                                  = "NetworkIDCacheTTL"
 
 	// Retired parameters
 
@@ -1017,6 +1018,8 @@ var defaultParameters = map[string]struct {
 	InproxyProxyOnBrokerClientFailedRetryPeriod:        {value: 30 * time.Second, minimum: time.Duration(0)},
 	InproxyProxyIncompatibleNetworkTypes:               {value: []string{}},
 	InproxyClientIncompatibleNetworkTypes:              {value: []string{}},
+
+	NetworkIDCacheTTL: {value: 500 * time.Millisecond, minimum: time.Duration(0)},
 }
 
 // IsServerSideOnly indicates if the parameter specified by name is used

--- a/psiphon/controller.go
+++ b/psiphon/controller.go
@@ -462,20 +462,25 @@ func (controller *Controller) SetDynamicConfig(sponsorID string, authorizations 
 func (controller *Controller) NetworkChanged() {
 
 	// Explicitly reset components that don't use the current network context.
+
 	controller.TerminateNextActiveTunnel()
+
 	if controller.inproxyProxyBrokerClientManager != nil {
 		controller.inproxyProxyBrokerClientManager.NetworkChanged()
 	}
 	controller.inproxyClientBrokerClientManager.NetworkChanged()
 
+	controller.config.networkIDGetter.FlushCache()
+
+	// Cancel the previous current network context, which will interrupt any
+	// operations using this context. Then create a new context for the new
+	// current network.
+
 	controller.currentNetworkMutex.Lock()
 	defer controller.currentNetworkMutex.Unlock()
 
-	// Cancel the previous current network context, which will interrupt any
-	// operations using this context.
 	controller.currentNetworkCancelFunc()
 
-	// Create a new context for the new current network.
 	controller.currentNetworkCtx, controller.currentNetworkCancelFunc =
 		context.WithCancel(context.Background())
 }

--- a/psiphon/dialParameters_test.go
+++ b/psiphon/dialParameters_test.go
@@ -307,6 +307,7 @@ func runDialParametersAndReplay(t *testing.T, tunnelProtocol string) {
 	dialParams.Succeeded()
 
 	testNetworkID = prng.HexString(8)
+	clientConfig.networkIDGetter.FlushCache()
 
 	dialParams, err = MakeDialParameters(
 		clientConfig, steeringIPCache, nil, nil, nil, canReplay, selectProtocol, serverEntries[0], nil, nil, false, 0, 0)

--- a/psiphon/inproxy_test.go
+++ b/psiphon/inproxy_test.go
@@ -192,7 +192,7 @@ func runInproxyBrokerDialParametersTest(t *testing.T) error {
 	previousBrokerClient := brokerClient
 	previousNetworkID := networkID
 	networkID = "NETWORK2"
-	config.networkIDGetter = newStaticNetworkGetter(networkID)
+	config.networkIDGetter = newCachingNetworkIDGetter(config, newStaticNetworkIDGetter(networkID))
 	config.SetResolver(resolver.NewResolver(&resolver.NetworkConfig{}, networkID))
 
 	brokerClient, brokerDialParams, err = manager.GetBrokerClient(networkID)
@@ -217,7 +217,7 @@ func runInproxyBrokerDialParametersTest(t *testing.T) error {
 	// Test: another replay after switch back to previous network ID
 
 	networkID = previousNetworkID
-	config.networkIDGetter = newStaticNetworkGetter(networkID)
+	config.networkIDGetter = newCachingNetworkIDGetter(config, newStaticNetworkIDGetter(networkID))
 
 	brokerClient, brokerDialParams, err = manager.GetBrokerClient(networkID)
 	if err != nil {
@@ -422,7 +422,7 @@ func runInproxyNATStateTest() error {
 	// Test: reset
 
 	networkID = "NETWORK2"
-	config.networkIDGetter = newStaticNetworkGetter(networkID)
+	config.networkIDGetter = newCachingNetworkIDGetter(config, newStaticNetworkIDGetter(networkID))
 
 	manager.reset()
 


### PR DESCRIPTION
- Use common/networkid.Get when enabled and when no NetworkIDGetter callback is configured. This adds a network ID for Windows.

- Move the network ID caching from common/networkid to a higher level that encompasses all platforms and GetNetworkID implementations.

- Make the cached network ID TTL a tactics-configurable parameter.