### PR TITLE
Added workaround for Go 1.24 printf analyzer

### DIFF
--- a/psiphon/common/inproxy/inproxy_test.go
+++ b/psiphon/common/inproxy/inproxy_test.go
@@ -51,14 +51,14 @@ import (
 func TestInproxy(t *testing.T) {
 	err := runTestInproxy(false)
 	if err != nil {
-		t.Errorf(errors.Trace(err).Error())
+		t.Error(errors.Trace(err).Error())
 	}
 }
 
 func TestInproxyMustUpgrade(t *testing.T) {
 	err := runTestInproxy(true)
 	if err != nil {
-		t.Errorf(errors.Trace(err).Error())
+		t.Error(errors.Trace(err).Error())
 	}
 }
 

--- a/psiphon/common/inproxy/matcher_test.go
+++ b/psiphon/common/inproxy/matcher_test.go
@@ -36,7 +36,7 @@ import (
 func TestMatcher(t *testing.T) {
 	err := runTestMatcher()
 	if err != nil {
-		t.Errorf(errors.Trace(err).Error())
+		t.Error(errors.Trace(err).Error())
 	}
 
 }
@@ -772,7 +772,7 @@ func randomIPAddress() string {
 func TestMatcherMultiQueue(t *testing.T) {
 	err := runTestMatcherMultiQueue()
 	if err != nil {
-		t.Errorf(errors.Trace(err).Error())
+		t.Error(errors.Trace(err).Error())
 	}
 }
 
@@ -1150,7 +1150,7 @@ func BenchmarkMatcherQueue(b *testing.B) {
 
 					err := m.addAnnouncementEntry(announcementEntry)
 					if err != nil {
-						b.Fatalf(errors.Trace(err).Error())
+						b.Fatal(errors.Trace(err).Error())
 					}
 				}
 			}
@@ -1160,7 +1160,7 @@ func BenchmarkMatcherQueue(b *testing.B) {
 
 			queueSize := m.announcementQueue.getLen()
 			if queueSize != size {
-				b.Fatalf(errors.Tracef("unexpected queue size: %d", queueSize).Error())
+				b.Fatal(errors.Tracef("unexpected queue size: %d", queueSize).Error())
 			}
 
 			for i := 0; i < b.N; i++ {
@@ -1203,12 +1203,12 @@ func BenchmarkMatcherQueue(b *testing.B) {
 
 				err := m.addAnnouncementEntry(announcementEntry)
 				if err != nil {
-					b.Fatalf(errors.Trace(err).Error())
+					b.Fatal(errors.Trace(err).Error())
 				}
 
 				match, _ := m.matchOffer(offerEntry)
 				if match == nil {
-					b.Fatalf(errors.TraceNew("unexpected no match").Error())
+					b.Fatal(errors.TraceNew("unexpected no match").Error())
 				}
 
 				m.removeAnnouncementEntry(false, match)

--- a/psiphon/common/inproxy/obfuscation_test.go
+++ b/psiphon/common/inproxy/obfuscation_test.go
@@ -36,7 +36,7 @@ func FuzzSessionPacketDeobfuscation(f *testing.F) {
 
 	rootSecret, err := GenerateRootObfuscationSecret()
 	if err != nil {
-		f.Fatalf(errors.Trace(err).Error())
+		f.Fatal(errors.Trace(err).Error())
 	}
 
 	n := 10
@@ -48,7 +48,7 @@ func FuzzSessionPacketDeobfuscation(f *testing.F) {
 		obfuscatedPacket, err := obfuscateSessionPacket(
 			rootSecret, true, packet, minPadding, maxPadding)
 		if err != nil {
-			f.Fatalf(errors.Trace(err).Error())
+			f.Fatal(errors.Trace(err).Error())
 		}
 
 		originals[i] = obfuscatedPacket
@@ -86,7 +86,7 @@ func FuzzSessionPacketDeobfuscation(f *testing.F) {
 func TestSessionPacketObfuscation(t *testing.T) {
 	err := runTestSessionPacketObfuscation()
 	if err != nil {
-		t.Errorf(errors.Trace(err).Error())
+		t.Error(errors.Trace(err).Error())
 	}
 }
 
@@ -349,7 +349,7 @@ func runTestSessionPacketObfuscation() error {
 func TestObfuscationReplayHistory(t *testing.T) {
 	err := runTestObfuscationReplayHistory()
 	if err != nil {
-		t.Errorf(errors.Trace(err).Error())
+		t.Error(errors.Trace(err).Error())
 	}
 }
 

--- a/psiphon/common/inproxy/sdp_test.go
+++ b/psiphon/common/inproxy/sdp_test.go
@@ -35,7 +35,7 @@ import (
 func TestProcessSDP(t *testing.T) {
 	err := runTestProcessSDP()
 	if err != nil {
-		t.Errorf(errors.Trace(err).Error())
+		t.Error(errors.Trace(err).Error())
 	}
 }
 

--- a/psiphon/common/inproxy/session_test.go
+++ b/psiphon/common/inproxy/session_test.go
@@ -38,7 +38,7 @@ import (
 func TestSessions(t *testing.T) {
 	err := runTestSessions()
 	if err != nil {
-		t.Errorf(errors.Trace(err).Error())
+		t.Error(errors.Trace(err).Error())
 	}
 }
 
@@ -582,7 +582,7 @@ func (t *testSessionRoundTripper) Close() error {
 func TestNoise(t *testing.T) {
 	err := runTestNoise()
 	if err != nil {
-		t.Errorf(errors.Trace(err).Error())
+		t.Error(errors.Trace(err).Error())
 	}
 }
 

--- a/psiphon/inproxy_test.go
+++ b/psiphon/inproxy_test.go
@@ -42,17 +42,17 @@ func TestInproxyComponents(t *testing.T) {
 
 	err := runInproxyBrokerDialParametersTest(t)
 	if err != nil {
-		t.Fatalf(errors.Trace(err).Error())
+		t.Fatal(errors.Trace(err).Error())
 	}
 
 	err = runInproxySTUNDialParametersTest()
 	if err != nil {
-		t.Fatalf(errors.Trace(err).Error())
+		t.Fatal(errors.Trace(err).Error())
 	}
 
 	err = runInproxyNATStateTest()
 	if err != nil {
-		t.Fatalf(errors.Trace(err).Error())
+		t.Fatal(errors.Trace(err).Error())
 	}
 
 	// TODO: test inproxyUDPConn multiplexed IPv6Synthesizer

--- a/psiphon/notice.go
+++ b/psiphon/notice.go
@@ -399,25 +399,30 @@ func (nl *noticeLogger) outputNoticeToRotatingFile(output []byte) error {
 	return nil
 }
 
+// nonConstantSprintf sidesteps the `go vet` "non-constant format string" check
+func nonConstantSprintf(format, _ string, args ...interface{}) string {
+	return fmt.Sprintf(format, args...)
+}
+
 // NoticeInfo is an informational message
 func NoticeInfo(format string, args ...interface{}) {
 	singletonNoticeLogger.outputNotice(
 		"Info", noticeIsDiagnostic,
-		"message", fmt.Sprintf(format, args...))
+		"message", nonConstantSprintf(format, "", args...))
 }
 
 // NoticeWarning is a warning message; typically a recoverable error condition
 func NoticeWarning(format string, args ...interface{}) {
 	singletonNoticeLogger.outputNotice(
 		"Warning", noticeIsDiagnostic,
-		"message", fmt.Sprintf(format, args...))
+		"message", nonConstantSprintf(format, "", args...))
 }
 
 // NoticeError is an error message; typically an unrecoverable error condition
 func NoticeError(format string, args ...interface{}) {
 	singletonNoticeLogger.outputNotice(
 		"Error", noticeIsDiagnostic,
-		"message", fmt.Sprintf(format, args...))
+		"message", nonConstantSprintf(format, "", args...))
 }
 
 // NoticeUserLog is a log message from the outer client user of tunnel-core

--- a/psiphon/server/server_test.go
+++ b/psiphon/server/server_test.go
@@ -2170,7 +2170,7 @@ func waitOnNotification(t *testing.T, c, timeoutSignal <-chan struct{}, timeoutM
 		select {
 		case <-c:
 		case <-timeoutSignal:
-			t.Fatalf(timeoutMessage)
+			t.Fatal(timeoutMessage)
 		}
 	}
 }

--- a/psiphon/tlsDialer_test.go
+++ b/psiphon/tlsDialer_test.go
@@ -607,9 +607,9 @@ func testTLSDialerCompatibility(t *testing.T, address string, fragmentClientHell
 			tlsProfile, success, repeats, tlsVersions)
 
 		if success == repeats {
-			t.Logf(result)
+			t.Log(result)
 		} else {
-			t.Errorf(result)
+			t.Error(result)
 		}
 	}
 }


### PR DESCRIPTION
- Added workaround for the new printf analyzer (https://tip.golang.org/doc/go1.24#vet)