### PR TITLE
Upgrade to wlynxg/anet v0.0.5

### DIFF
--- a/ClientLibrary/Dockerfile
+++ b/ClientLibrary/Dockerfile
@@ -29,7 +29,7 @@ RUN curl -L https://storage.googleapis.com/golang/$GOVERSION.linux-amd64.tar.gz 
    && echo $GOVERSION > $GOROOT/VERSION
 
 # Setup Android Environment.
-ENV ANDROID_NDK_VERSION=r17b
+ENV ANDROID_NDK_VERSION=r22b
 ENV ANDROID_NDK_TOOLCHAIN_ROOT=/android-ndk-toolchain
 
 # Setup Android NDK

--- a/ClientLibrary/make.bash
+++ b/ClientLibrary/make.bash
@@ -51,20 +51,26 @@ build_for_android () {
 
   prepare_build android
 
+  # Required workaround for an PSIPHON_ENABLE_INPROXY dependency:
+  # https://github.com/wlynxg/anet/tree/5501d401a269290292909e6cc75f105571f97cfa?tab=readme-ov-file#how-to-build-with-go-1230-or-later
+  #
+  # TODO: conditional on PSIPHON_ENABLE_INPROXY build tag?
+  ANDROID_LDFLAGS="-checklinkname=0 $LDFLAGS"
+
   TARGET_ARCH=arm
   ARMV=7
 
   CC="${ANDROID_NDK_TOOLCHAIN_ROOT}/${TARGET_ARCH}/bin/arm-linux-androideabi-clang" \
   CXX="${ANDROID_NDK_TOOLCHAIN_ROOT}/${TARGET_ARCH}/bin/arm-linux-androideabi-clang++" \
   GOARM=${ARMV} \
-  GOOS=${TARGET_OS} GOARCH=${TARGET_ARCH} go build -buildmode=c-shared -ldflags "$LDFLAGS" -tags "${BUILD_TAGS}" -o "${OUTPUT_DIR}/${TARGET_ARCH}${ARMV}/libpsiphontunnel.so" PsiphonTunnel.go
+  GOOS=${TARGET_OS} GOARCH=${TARGET_ARCH} go build -buildmode=c-shared -ldflags "$ANDROID_LDFLAGS" -tags "${BUILD_TAGS}" -o "${OUTPUT_DIR}/${TARGET_ARCH}${ARMV}/libpsiphontunnel.so" PsiphonTunnel.go
 
 
   TARGET_ARCH=arm64
 
   CC="${ANDROID_NDK_TOOLCHAIN_ROOT}/${TARGET_ARCH}/bin/aarch64-linux-android-clang" \
   CXX="${ANDROID_NDK_TOOLCHAIN_ROOT}/${TARGET_ARCH}/bin/aarch64-linux-android-clang++" \
-  GOOS=${TARGET_OS} GOARCH=${TARGET_ARCH} go build -buildmode=c-shared -ldflags "$LDFLAGS" -tags "${BUILD_TAGS}" -o "${OUTPUT_DIR}/${TARGET_ARCH}/libpsiphontunnel.so" PsiphonTunnel.go
+  GOOS=${TARGET_OS} GOARCH=${TARGET_ARCH} go build -buildmode=c-shared -ldflags "$ANDROID_LDFLAGS" -tags "${BUILD_TAGS}" -o "${OUTPUT_DIR}/${TARGET_ARCH}/libpsiphontunnel.so" PsiphonTunnel.go
 
 }
 

--- a/MobileLibrary/Android/make.bash
+++ b/MobileLibrary/Android/make.bash
@@ -21,7 +21,13 @@ BUILDREPO="https://github.com/Psiphon-Labs/psiphon-tunnel-core.git"
 BUILDREV=$(git rev-parse --short HEAD)
 GOVERSION=$(go version | perl -ne '/go version (.*?) / && print $1')
 
+# -checklinkname=0 is a required workaround for an PSIPHON_ENABLE_INPROXY dependency:
+# https://github.com/wlynxg/anet/tree/5501d401a269290292909e6cc75f105571f97cfa?tab=readme-ov-file#how-to-build-with-go-1230-or-later
+#
+# TODO: conditional on PSIPHON_ENABLE_INPROXY build tag?
+
 LDFLAGS="\
+-checklinkname=0 \
 -s \
 -w \
 -X github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/buildinfo.buildDate=$BUILDDATE \

--- a/go.mod
+++ b/go.mod
@@ -84,7 +84,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8
 	github.com/wader/filtertransport v0.0.0-20200316221534-bdd9e61eee78
-	github.com/wlynxg/anet v0.0.1
+	github.com/wlynxg/anet v0.0.5
 	golang.org/x/crypto v0.35.0
 	golang.org/x/net v0.36.0
 	golang.org/x/sync v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -287,6 +287,8 @@ github.com/wader/filtertransport v0.0.0-20200316221534-bdd9e61eee78 h1:9sreu9e9K
 github.com/wader/filtertransport v0.0.0-20200316221534-bdd9e61eee78/go.mod h1:HazXTRLhXFyq80TQp7PUXi6BKE6mS+ydEdzEqNBKopQ=
 github.com/wlynxg/anet v0.0.1 h1:VbkEEgHxPSrRQSiyRd0pmrbcEQAEU2TTb8fb4DmSYoQ=
 github.com/wlynxg/anet v0.0.1/go.mod h1:eay5PRQr7fIVAMbTbchTnO9gG65Hg/uYGdc7mguHxoA=
+github.com/wlynxg/anet v0.0.5 h1:J3VJGi1gvo0JwZ/P1/Yc/8p63SoW98B5dHkYDmpgvvU=
+github.com/wlynxg/anet v0.0.5/go.mod h1:eay5PRQr7fIVAMbTbchTnO9gG65Hg/uYGdc7mguHxoA=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=

--- a/vendor/github.com/wlynxg/anet/README.md
+++ b/vendor/github.com/wlynxg/anet/README.md
@@ -25,9 +25,7 @@ The specific fix logic includes:
 Removing the `Bind()` operation on `Netlink` sockets in the `NetlinkRIB()` function.
 Using `ioctl` based on the Index number returned by `RTM_GETADDR` to retrieve the network card's name, MTU, and flags.
 
-
-
-
+There are two implementations of the `net` package: one from the [Go standard library](https://pkg.go.dev/net) and another from the [golang.org/x/net](https://pkg.go.dev/golang.org/x/net) module. Both of these implementations have the same issues in the Android environment. The `anet` package should be compatible with both of them.
 
 ## Test Code
 ### net.Interface()
@@ -116,4 +114,13 @@ result:
 ...
 192.168.6.143/24
 fe80::7e4f:4446:eb3:1eb8/64
+```
+
+## Other issues due to #40569
+- https://github.com/golang/go/issues/68082
+
+## How to build with Go 1.23.0 or later
+The `anet` library internally relies on `//go:linkname` directive. Since the usage of `//go:linkname` has been restricted since Go 1.23.0 ([Go 1.23 Release Notes](https://tip.golang.org/doc/go1.23#linker)), it is necessary to specify the `-checklinkname=0` linker flag when building the `anet` package with Go 1.23.0 or later. Without this flag, the following linker error will occur:
+```
+link: github.com/wlynxg/anet: invalid reference to net.zoneCache
 ```

--- a/vendor/github.com/wlynxg/anet/README_zh.md
+++ b/vendor/github.com/wlynxg/anet/README_zh.md
@@ -20,3 +20,6 @@
 
 - 取消了`NetlinkRIB()`函数中对`Netlink`套接字的`Bind()`操作。
 - 根据`RTM_GETADDR`返回的Index号，使用`ioctl`获取其网卡的名称、MTU和标志位。
+
+## 由于 #40569 导致的其他问题
+- #[68082](https://github.com/golang/go/issues/68082)

--- a/vendor/github.com/wlynxg/anet/android_api_level.go
+++ b/vendor/github.com/wlynxg/anet/android_api_level.go
@@ -1,0 +1,7 @@
+//go:build !(android && cgo)
+
+package anet
+
+func androidDeviceApiLevel() int {
+	return -1
+}

--- a/vendor/github.com/wlynxg/anet/android_api_level_cgo.go
+++ b/vendor/github.com/wlynxg/anet/android_api_level_cgo.go
@@ -1,0 +1,23 @@
+//go:build android && cgo
+
+package anet
+
+// #include <android/api-level.h>
+import "C"
+
+import "sync"
+
+var (
+	apiLevel int
+	once     sync.Once
+)
+
+// Returns the API level of the device we're actually running on, or -1 on failure.
+// The returned value is equivalent to the Java Build.VERSION.SDK_INT API.
+func androidDeviceApiLevel() int {
+	once.Do(func() {
+		apiLevel = int(C.android_get_device_api_level())
+	})
+
+	return apiLevel
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -491,7 +491,7 @@ github.com/vishvananda/netns
 # github.com/wader/filtertransport v0.0.0-20200316221534-bdd9e61eee78
 ## explicit; go 1.12
 github.com/wader/filtertransport
-# github.com/wlynxg/anet v0.0.1
+# github.com/wlynxg/anet v0.0.5
 ## explicit; go 1.20
 github.com/wlynxg/anet
 # github.com/x448/float16 v0.8.4


### PR DESCRIPTION
- Uses stock net.Interfaces for Android < 11
- CGO builds (including Android and Client Library) automatically detect Android version
- Fixes IPv6 zoneCache issue with net.Listen after anet.Interfaces
- Limitations
  - Non-CGO builds now default to stock net.Interface, even on Android 11+
  - Currently requires `-checklinkname=0` linker flag workaround