### PR TITLE
Rework QUIC extended UDP socket support

### DIFF
--- a/psiphon/common/quic/quic_test.go
+++ b/psiphon/common/quic/quic_test.go
@@ -102,10 +102,14 @@ func runQUIC(
 
 	obfuscationKey := prng.HexString(32)
 
+	// Disabling MTU discovery is exercised in in-proxy test cases.
+	disablePathMTUDiscovery := false
+
 	listener, err := Listen(
 		nil,
 		irregularTunnelLogger,
 		"127.0.0.1:0",
+		disablePathMTUDiscovery,
 		0,
 		obfuscationKey,
 		enableGQUIC)

--- a/psiphon/meekConn.go
+++ b/psiphon/meekConn.go
@@ -425,6 +425,11 @@ func DialMeek(
 
 		meek.connManager = newMeekUnderlyingConnManager(nil, nil, udpDialer)
 
+		// Limitation: currently, the meekUnderlyingPacketConn wrapping done by
+		// dialPacketConn masks the quic-go.OOBCapablePacketConn capabilities
+		// of the underlying *net.UDPConn. With these capabilities unavailable,
+		// path MTU discovery and UDP socket buffer optimizations will be disabled.
+
 		var err error
 		transport, err = quic.NewQUICTransporter(
 			ctx,

--- a/psiphon/server/server_test.go
+++ b/psiphon/server/server_test.go
@@ -1042,7 +1042,10 @@ func runServer(t *testing.T, runConfig *runServerConfig) {
 
 	serverConfig["RunPacketManipulator"] = runConfig.doPacketManipulation
 
-	if protocol.TunnelProtocolUsesQUIC(runConfig.tunnelProtocol) && quic.GQUICEnabled() {
+	if protocol.TunnelProtocolUsesQUIC(runConfig.tunnelProtocol) &&
+		!runConfig.limitQUICVersions &&
+		quic.GQUICEnabled() {
+
 		// Enable legacy QUIC version support.
 		serverConfig["EnableGQUIC"] = true
 	}

--- a/psiphon/server/tunnelServer.go
+++ b/psiphon/server/tunnelServer.go
@@ -180,7 +180,7 @@ func (server *TunnelServer) Run() error {
 				// back to the client, via the proxy, are encapsulated in
 				// SRTP packet payloads, and the maximum QUIC packet size
 				// must be adjusted to fit. MTU discovery is disabled so the
-				// maximum packewt size will not grow.
+				// maximum packet size will not grow.
 				//
 				// Limitation: the WebRTC data channel mode does not have the
 				// same QUIC packet size constraint, since data channel


### PR DESCRIPTION
- Server-side path MTU discovery is now enabled for direct QUIC tunnels
- Larger socket buffers now enabled in more cases
- Split some OOBCapablePacketConn functionality into a distinct type; more explicit type wrapping; additional typoe checking
- Fix server_test limitQUICVersions case, ensuring gQUIC (and multiplexer) isn't enabled