### PR TITLE
Add 16KB page size linker flags for Android 15 compatibility

### DIFF
--- a/MobileLibrary/Android/make.bash
+++ b/MobileLibrary/Android/make.bash
@@ -26,6 +26,9 @@ GOVERSION=$(go version | perl -ne '/go version (.*?) / && print $1')
 #
 # TODO: conditional on PSIPHON_ENABLE_INPROXY build tag?
 
+# 16KB page size alignment for Android compatibility
+export CGO_LDFLAGS="${CGO_LDFLAGS:-} -Wl,-z,max-page-size=16384,-z,common-page-size=16384"
+
 LDFLAGS="\
 -checklinkname=0 \
 -s \
@@ -34,6 +37,7 @@ LDFLAGS="\
 -X github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/buildinfo.buildRepo=$BUILDREPO \
 -X github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/buildinfo.buildRev=$BUILDREV \
 -X github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/buildinfo.goVersion=$GOVERSION \
+-extldflags=-Wl,-z,max-page-size=16384,-z,common-page-size=16384 \
 "
 
 echo -e "${BUILDDATE}\n${BUILDREPO}\n${BUILDREV}\n" > $BUILDINFOFILE


### PR DESCRIPTION
Required to satisfy Google Play 16KB page size requirement: https://android-developers.googleblog.com/2025/05/prepare-play-apps-for-devices-with-16kb-page-size.html