### PR TITLE
Android: fix crash from NetworkInterface.getNetworkInterfaces() NPE

### DIFF
--- a/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
+++ b/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
@@ -1163,6 +1163,8 @@ public class PsiphonTunnel {
             }
         } catch (SocketException e) {
             throw new Exception("hasIPv6Route failed", e);
+        } catch (NullPointerException e) {
+            throw new Exception("hasIPv6Route failed", e);
         }
 
         return false;


### PR DESCRIPTION
Work around a framework bug where getNetworkInterfaces() may throw NullPointerException on API < 31 when a virtual interface has no parent. See https://issuetracker.google.com/issues/204913332