### PR TITLE
Performance fixes

### DIFF
--- a/psiphon/common/dsl/fetcher.go
+++ b/psiphon/common/dsl/fetcher.go
@@ -583,7 +583,7 @@ func (f *Fetcher) doDiscoverServerEntriesRequest(
 			DiscoverCount:     int32(discoverCount),
 		}
 
-		var response *DiscoverServerEntriesResponse
+		var response DiscoverServerEntriesResponse
 		doRetry, err := f.doRelayedRequest(
 			ctx, requestTypeDiscoverServerEntries, request, &response)
 
@@ -628,7 +628,7 @@ func (f *Fetcher) doGetServerEntriesRequest(
 			ServerEntryTags:   tags,
 		}
 
-		var response *GetServerEntriesResponse
+		var response GetServerEntriesResponse
 		doRetry, err := f.doRelayedRequest(
 			ctx, requestTypeGetServerEntries, request, &response)
 
@@ -675,7 +675,7 @@ func (f *Fetcher) doGetActiveOSLsRequest(ctx context.Context) ([]OSLID, error) {
 			BaseAPIParameters: f.packedAPIParameters,
 		}
 
-		var response *GetActiveOSLsResponse
+		var response GetActiveOSLsResponse
 		doRetry, err := f.doRelayedRequest(
 			ctx, requestTypeGetActiveOSLs, request, &response)
 		if err == nil {
@@ -714,7 +714,7 @@ func (f *Fetcher) doGetOSLFileSpecsRequest(
 			OSLIDs:            IDs,
 		}
 
-		var response *GetOSLFileSpecsResponse
+		var response GetOSLFileSpecsResponse
 		doRetry, err := f.doRelayedRequest(
 			ctx, requestTypeGetOSLFileSpecs, request, &response)
 
@@ -805,7 +805,7 @@ func (f *Fetcher) doRelayedRequest(
 
 	// Remove the relay wrapping.
 
-	var relayedResponse *RelayedResponse
+	var relayedResponse RelayedResponse
 	err = cbor.Unmarshal(cborRelayedResponse, &relayedResponse)
 	if err != nil {
 		return false, errors.Trace(err)
@@ -859,7 +859,7 @@ func (f *Fetcher) loadOSLStates(ctx context.Context, reassembleKeys bool) ([]*fe
 			continue
 		}
 
-		var state *fetcherOSLState
+		var state fetcherOSLState
 		err = cbor.Unmarshal(cborState, &state)
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -878,13 +878,13 @@ func (f *Fetcher) loadOSLStates(ctx context.Context, reassembleKeys bool) ([]*fe
 
 			if reassembleKeys {
 
-				var fileSpec *osl.OSLFileSpec
+				var fileSpec osl.OSLFileSpec
 				err = cbor.Unmarshal(state.FileSpec, &fileSpec)
 				if err != nil {
 					return nil, errors.Trace(err)
 				}
 
-				ok, key, err := osl.ReassembleOSLKey(fileSpec, f.config.DatastoreSLOKLookup)
+				ok, key, err := osl.ReassembleOSLKey(&fileSpec, f.config.DatastoreSLOKLookup)
 				if err != nil {
 					return nil, errors.Trace(err)
 				}
@@ -899,7 +899,7 @@ func (f *Fetcher) loadOSLStates(ctx context.Context, reassembleKeys bool) ([]*fe
 					state.State = oslStateHasKey
 					state.Key = key
 					state.FileSpec = nil
-					err = f.storeOSLState(ID, state)
+					err = f.storeOSLState(ID, &state)
 					if err != nil {
 						return nil, errors.Trace(err)
 					}
@@ -916,7 +916,7 @@ func (f *Fetcher) loadOSLStates(ctx context.Context, reassembleKeys bool) ([]*fe
 			f.config.DoGarbageCollection()
 		}
 
-		states = append(states, state)
+		states = append(states, &state)
 	}
 
 	return states, nil

--- a/psiphon/common/dsl/relay.go
+++ b/psiphon/common/dsl/relay.go
@@ -393,7 +393,7 @@ func (r *Relay) HandleRequest(
 			len(cborRelayedRequest), MaxRelayPayloadSize)
 	}
 
-	var relayedRequest *RelayedRequest
+	var relayedRequest RelayedRequest
 	err := cbor.Unmarshal(cborRelayedRequest, &relayedRequest)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/psiphon/common/inproxy/api.go
+++ b/psiphon/common/inproxy/api.go
@@ -1110,9 +1110,9 @@ func MarshalProxyAnnounceRequest(request *ProxyAnnounceRequest) ([]byte, error) 
 }
 
 func UnmarshalProxyAnnounceRequest(payload []byte) (*ProxyAnnounceRequest, error) {
-	var request *ProxyAnnounceRequest
+	var request ProxyAnnounceRequest
 	err := unmarshalRecord(recordTypeAPIProxyAnnounceRequest, payload, &request)
-	return request, errors.Trace(err)
+	return &request, errors.Trace(err)
 }
 
 func MarshalProxyAnnounceResponse(response *ProxyAnnounceResponse) ([]byte, error) {
@@ -1121,9 +1121,9 @@ func MarshalProxyAnnounceResponse(response *ProxyAnnounceResponse) ([]byte, erro
 }
 
 func UnmarshalProxyAnnounceResponse(payload []byte) (*ProxyAnnounceResponse, error) {
-	var response *ProxyAnnounceResponse
+	var response ProxyAnnounceResponse
 	err := unmarshalRecord(recordTypeAPIProxyAnnounceResponse, payload, &response)
-	return response, errors.Trace(err)
+	return &response, errors.Trace(err)
 }
 
 func MarshalProxyAnswerRequest(request *ProxyAnswerRequest) ([]byte, error) {
@@ -1132,9 +1132,9 @@ func MarshalProxyAnswerRequest(request *ProxyAnswerRequest) ([]byte, error) {
 }
 
 func UnmarshalProxyAnswerRequest(payload []byte) (*ProxyAnswerRequest, error) {
-	var request *ProxyAnswerRequest
+	var request ProxyAnswerRequest
 	err := unmarshalRecord(recordTypeAPIProxyAnswerRequest, payload, &request)
-	return request, errors.Trace(err)
+	return &request, errors.Trace(err)
 }
 
 func MarshalProxyAnswerResponse(response *ProxyAnswerResponse) ([]byte, error) {
@@ -1143,9 +1143,9 @@ func MarshalProxyAnswerResponse(response *ProxyAnswerResponse) ([]byte, error) {
 }
 
 func UnmarshalProxyAnswerResponse(payload []byte) (*ProxyAnswerResponse, error) {
-	var response *ProxyAnswerResponse
+	var response ProxyAnswerResponse
 	err := unmarshalRecord(recordTypeAPIProxyAnswerResponse, payload, &response)
-	return response, errors.Trace(err)
+	return &response, errors.Trace(err)
 }
 
 func MarshalClientOfferRequest(request *ClientOfferRequest) ([]byte, error) {
@@ -1154,9 +1154,9 @@ func MarshalClientOfferRequest(request *ClientOfferRequest) ([]byte, error) {
 }
 
 func UnmarshalClientOfferRequest(payload []byte) (*ClientOfferRequest, error) {
-	var request *ClientOfferRequest
+	var request ClientOfferRequest
 	err := unmarshalRecord(recordTypeAPIClientOfferRequest, payload, &request)
-	return request, errors.Trace(err)
+	return &request, errors.Trace(err)
 }
 
 func MarshalClientOfferResponse(response *ClientOfferResponse) ([]byte, error) {
@@ -1165,9 +1165,9 @@ func MarshalClientOfferResponse(response *ClientOfferResponse) ([]byte, error) {
 }
 
 func UnmarshalClientOfferResponse(payload []byte) (*ClientOfferResponse, error) {
-	var response *ClientOfferResponse
+	var response ClientOfferResponse
 	err := unmarshalRecord(recordTypeAPIClientOfferResponse, payload, &response)
-	return response, errors.Trace(err)
+	return &response, errors.Trace(err)
 }
 
 func MarshalClientRelayedPacketRequest(request *ClientRelayedPacketRequest) ([]byte, error) {
@@ -1176,9 +1176,9 @@ func MarshalClientRelayedPacketRequest(request *ClientRelayedPacketRequest) ([]b
 }
 
 func UnmarshalClientRelayedPacketRequest(payload []byte) (*ClientRelayedPacketRequest, error) {
-	var request *ClientRelayedPacketRequest
+	var request ClientRelayedPacketRequest
 	err := unmarshalRecord(recordTypeAPIClientRelayedPacketRequest, payload, &request)
-	return request, errors.Trace(err)
+	return &request, errors.Trace(err)
 }
 
 func MarshalClientRelayedPacketResponse(response *ClientRelayedPacketResponse) ([]byte, error) {
@@ -1187,9 +1187,9 @@ func MarshalClientRelayedPacketResponse(response *ClientRelayedPacketResponse) (
 }
 
 func UnmarshalClientRelayedPacketResponse(payload []byte) (*ClientRelayedPacketResponse, error) {
-	var response *ClientRelayedPacketResponse
+	var response ClientRelayedPacketResponse
 	err := unmarshalRecord(recordTypeAPIClientRelayedPacketResponse, payload, &response)
-	return response, errors.Trace(err)
+	return &response, errors.Trace(err)
 }
 
 func MarshalBrokerServerReport(request *BrokerServerReport) ([]byte, error) {
@@ -1198,9 +1198,9 @@ func MarshalBrokerServerReport(request *BrokerServerReport) ([]byte, error) {
 }
 
 func UnmarshalBrokerServerReport(payload []byte) (*BrokerServerReport, error) {
-	var request *BrokerServerReport
+	var request BrokerServerReport
 	err := unmarshalRecord(recordTypeAPIBrokerServerReport, payload, &request)
-	return request, errors.Trace(err)
+	return &request, errors.Trace(err)
 }
 
 func MarshalServerProxyQualityRequest(request *ServerProxyQualityRequest) ([]byte, error) {
@@ -1209,9 +1209,9 @@ func MarshalServerProxyQualityRequest(request *ServerProxyQualityRequest) ([]byt
 }
 
 func UnmarshalServerProxyQualityRequest(payload []byte) (*ServerProxyQualityRequest, error) {
-	var request *ServerProxyQualityRequest
+	var request ServerProxyQualityRequest
 	err := unmarshalRecord(recordTypeAPIServerProxyQualityRequest, payload, &request)
-	return request, errors.Trace(err)
+	return &request, errors.Trace(err)
 }
 
 func MarshalServerProxyQualityResponse(response *ServerProxyQualityResponse) ([]byte, error) {
@@ -1220,9 +1220,9 @@ func MarshalServerProxyQualityResponse(response *ServerProxyQualityResponse) ([]
 }
 
 func UnmarshalServerProxyQualityResponse(payload []byte) (*ServerProxyQualityResponse, error) {
-	var response *ServerProxyQualityResponse
+	var response ServerProxyQualityResponse
 	err := unmarshalRecord(recordTypeAPIServerProxyQualityResponse, payload, &response)
-	return response, errors.Trace(err)
+	return &response, errors.Trace(err)
 }
 
 func MarshalClientDSLRequest(request *ClientDSLRequest) ([]byte, error) {
@@ -1231,9 +1231,9 @@ func MarshalClientDSLRequest(request *ClientDSLRequest) ([]byte, error) {
 }
 
 func UnmarshalClientDSLRequest(payload []byte) (*ClientDSLRequest, error) {
-	var request *ClientDSLRequest
+	var request ClientDSLRequest
 	err := unmarshalRecord(recordTypeAPIClientDSLRequest, payload, &request)
-	return request, errors.Trace(err)
+	return &request, errors.Trace(err)
 }
 
 func MarshalClientDSLResponse(response *ClientDSLResponse) ([]byte, error) {
@@ -1242,7 +1242,7 @@ func MarshalClientDSLResponse(response *ClientDSLResponse) ([]byte, error) {
 }
 
 func UnmarshalClientDSLResponse(payload []byte) (*ClientDSLResponse, error) {
-	var response *ClientDSLResponse
+	var response ClientDSLResponse
 	err := unmarshalRecord(recordTypeAPIClientDSLResponse, payload, &response)
-	return response, errors.Trace(err)
+	return &response, errors.Trace(err)
 }

--- a/psiphon/common/parameters/parameters.go
+++ b/psiphon/common/parameters/parameters.go
@@ -582,6 +582,7 @@ const (
 	ProxyProtocolHeaderDefaultEnableProbability        = "ProxyProtocolHeaderDefaultEnableProbability"
 	SSHChannelWindowSize                               = "SSHChannelWindowSize"
 	SSHPacketTunnelChannelWindowSize                   = "SSHPacketTunnelChannelWindowSize"
+	DisableServerEntriesReporter                       = "DisableServerEntriesReporter"
 
 	// Retired parameters
 
@@ -1246,6 +1247,8 @@ var defaultParameters = map[string]struct {
 
 	SSHChannelWindowSize:             {value: 0, minimum: 0},
 	SSHPacketTunnelChannelWindowSize: {value: 0, minimum: 0},
+
+	DisableServerEntriesReporter: {value: false},
 }
 
 // IsServerSideOnly indicates if the parameter specified by name is used

--- a/psiphon/config.go
+++ b/psiphon/config.go
@@ -801,6 +801,12 @@ type Config struct {
 	// packets. The valid range is 1-128. When 0, the default of 16 is used.
 	SSHPacketTunnelChannelWindowSize *int `json:",omitempty"`
 
+	// DisableServerEntriesReporter disables the server entry scan that
+	// reports the AvailableEgressRegions notice, as well as CandidateServers
+	// diagnostics. When the egress region list is not required, disabling
+	// this expensive scan can improve datastore performance on slower devices.
+	DisableServerEntriesReporter *bool `json:",omitempty"`
+
 	//
 	// The following parameters are deprecated.
 	//
@@ -3209,6 +3215,10 @@ func (config *Config) makeConfigParameters() map[string]interface{} {
 	}
 
 	if config.ServerEntryIteratorMaxMoveToFront != nil {
+		applyParameters[parameters.ServerEntryIteratorMaxMoveToFront] = *config.ServerEntryIteratorMaxMoveToFront
+	}
+
+	if config.ServerEntryIteratorResetProbability != nil {
 		applyParameters[parameters.ServerEntryIteratorResetProbability] = *config.ServerEntryIteratorResetProbability
 	}
 
@@ -3226,6 +3236,10 @@ func (config *Config) makeConfigParameters() map[string]interface{} {
 
 	if config.SSHPacketTunnelChannelWindowSize != nil {
 		applyParameters[parameters.SSHPacketTunnelChannelWindowSize] = *config.SSHPacketTunnelChannelWindowSize
+	}
+
+	if config.DisableServerEntriesReporter != nil {
+		applyParameters[parameters.DisableServerEntriesReporter] = *config.DisableServerEntriesReporter
 	}
 
 	// When adding new config dial parameters that may override tactics, also

--- a/psiphon/controller.go
+++ b/psiphon/controller.go
@@ -2227,6 +2227,8 @@ func (controller *Controller) launchEstablishing() {
 	}
 	controller.setTunnelPoolSize(tunnelPoolSize)
 
+	disableServerEntriesReporter := p.Bool(parameters.DisableServerEntriesReporter)
+
 	p.Close()
 
 	// Trigger CandidateServers and AvailableEgressRegions notices. By default,
@@ -2263,12 +2265,14 @@ func (controller *Controller) launchEstablishing() {
 	// lists) with the original; the contents of these slices don't change
 	// past this point. The rate limiter should not be used by
 	// serverEntriesReporter, but is cleared just in case.
-	copyConstraints := *controller.protocolSelectionConstraints
-	copyConstraints.inproxyClientDialRateLimiter = nil
-	controller.signalServerEntriesReporter(
-		&serverEntriesReportRequest{
-			constraints: &copyConstraints,
-		})
+	if !disableServerEntriesReporter {
+		copyConstraints := *controller.protocolSelectionConstraints
+		copyConstraints.inproxyClientDialRateLimiter = nil
+		controller.signalServerEntriesReporter(
+			&serverEntriesReportRequest{
+				constraints: &copyConstraints,
+			})
+	}
 
 	if controller.protocolSelectionConstraints.hasInitialProtocols() ||
 		tunnelPoolSize > 1 {
@@ -2279,7 +2283,7 @@ func (controller *Controller) launchEstablishing() {
 		// requirements can't be met, the constraint and/or pool size are
 		// adjusted in order to avoid spinning unable to select any protocol
 		// or trying to establish more tunnels than is possible.
-		controller.doConstraintsScan()
+		controller.doConstraintsScan(controller.establishCtx)
 	}
 
 	controller.resetServerEntryIterationMetrics()
@@ -2336,7 +2340,7 @@ func (controller *Controller) getConnectionWorkerPoolSize(
 	return workerPoolSize
 }
 
-func (controller *Controller) doConstraintsScan() {
+func (controller *Controller) doConstraintsScan(ctx context.Context) {
 
 	// Scan over server entries in order to check and adjust any initial
 	// tunnel protocol limit and tunnel pool size.
@@ -2382,8 +2386,13 @@ func (controller *Controller) doConstraintsScan() {
 		}
 
 		select {
+		case <-ctx.Done():
+			// Don't block establishment restart: cancel the scan.
+			scanCancelled = true
+			return false
 		case <-controller.runCtx.Done():
 			// Don't block controller shutdown: cancel the scan.
+			scanCancelled = true
 			return false
 		default:
 			return true
@@ -2540,8 +2549,12 @@ func (controller *Controller) establishCandidateGenerator() {
 	// from reported tunnel establishment duration.
 	var totalNetworkWaitDuration time.Duration
 
-	applyServerAffinity, iterator, err := NewServerEntryIterator(controller.config)
+	applyServerAffinity, iterator, err := NewServerEntryIterator(
+		controller.establishCtx, controller.config)
 	if err != nil {
+		if controller.isStopEstablishing() {
+			return
+		}
 		NoticeError("failed to iterate over candidates: %v", errors.Trace(err))
 		controller.SignalComponentFailure()
 		return
@@ -2608,8 +2621,11 @@ loop:
 			roundNetworkWaitDuration += networkWaitDuration
 			totalNetworkWaitDuration += networkWaitDuration
 
-			serverEntry, err := iterator.Next()
+			serverEntry, err := iterator.Next(controller.establishCtx)
 			if err != nil {
+				if controller.isStopEstablishing() {
+					break loop
+				}
 				NoticeError("failed to get next candidate: %v", errors.Trace(err))
 				controller.SignalComponentFailure()
 				return
@@ -2803,8 +2819,11 @@ loop:
 		timer.Stop()
 
 		if resetIterator {
-			err := iterator.Reset()
+			err := iterator.Reset(controller.establishCtx)
 			if err != nil {
+				if controller.isStopEstablishing() {
+					break loop
+				}
 				NoticeError("failed to reset iterator: %v", errors.Trace(err))
 				controller.SignalComponentFailure()
 				return

--- a/psiphon/dataStore.go
+++ b/psiphon/dataStore.go
@@ -674,7 +674,8 @@ type ServerEntryIterator struct {
 // NewServerEntryIterator and any returned ServerEntryIterator are not
 // designed for concurrent use as not all related datastore operations are
 // performed in a single transaction.
-func NewServerEntryIterator(config *Config) (bool, *ServerEntryIterator, error) {
+func NewServerEntryIterator(
+	ctx context.Context, config *Config) (bool, *ServerEntryIterator, error) {
 
 	// When configured, this target server entry is the only candidate
 	if config.TargetServerEntry != "" {
@@ -694,7 +695,7 @@ func NewServerEntryIterator(config *Config) (bool, *ServerEntryIterator, error) 
 		updateMoveToFrontMetrics: true,
 	}
 
-	err = iterator.reset(true)
+	err = iterator.reset(ctx, true)
 	if err != nil {
 		return false, nil, errors.Trace(err)
 	}
@@ -702,7 +703,8 @@ func NewServerEntryIterator(config *Config) (bool, *ServerEntryIterator, error) 
 	return applyServerAffinity, iterator, nil
 }
 
-func NewTacticsServerEntryIterator(config *Config) (*ServerEntryIterator, error) {
+func NewTacticsServerEntryIterator(
+	ctx context.Context, config *Config) (*ServerEntryIterator, error) {
 
 	// When configured, this target server entry is the only candidate
 	if config.TargetServerEntry != "" {
@@ -715,7 +717,7 @@ func NewTacticsServerEntryIterator(config *Config) (*ServerEntryIterator, error)
 		isTacticsServerEntryIterator: true,
 	}
 
-	err := iterator.reset(true)
+	err := iterator.reset(ctx, true)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -723,7 +725,8 @@ func NewTacticsServerEntryIterator(config *Config) (*ServerEntryIterator, error)
 	return iterator, nil
 }
 
-func NewPruneServerEntryIterator(config *Config) (*ServerEntryIterator, error) {
+func NewPruneServerEntryIterator(
+	ctx context.Context, config *Config) (*ServerEntryIterator, error) {
 
 	// There is no TargetServerEntry case when pruning.
 
@@ -732,7 +735,7 @@ func NewPruneServerEntryIterator(config *Config) (*ServerEntryIterator, error) {
 		isPruneServerEntryIterator: true,
 	}
 
-	err := iterator.reset(true)
+	err := iterator.reset(ctx, true)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -796,7 +799,7 @@ func newTargetServerEntryIterator(config *Config, isTactics bool) (bool, *Server
 		updateMoveToFrontMetrics:     !isTactics,
 	}
 
-	err = iterator.reset(true)
+	err = iterator.reset(context.Background(), true)
 	if err != nil {
 		return false, nil, errors.Trace(err)
 	}
@@ -808,11 +811,12 @@ func newTargetServerEntryIterator(config *Config, isTactics bool) (bool, *Server
 
 // Reset a NewServerEntryIterator to the start of its cycle. The next
 // call to Next will return the first server entry.
-func (iterator *ServerEntryIterator) Reset() error {
-	return iterator.reset(false)
+func (iterator *ServerEntryIterator) Reset(ctx context.Context) error {
+	return iterator.reset(ctx, false)
 }
 
-func (iterator *ServerEntryIterator) reset(isInitialRound bool) error {
+func (iterator *ServerEntryIterator) reset(ctx context.Context, isInitialRound bool) error {
+
 	iterator.Close()
 
 	if iterator.isTargetServerEntryIterator {
@@ -853,6 +857,9 @@ func (iterator *ServerEntryIterator) reset(isInitialRound bool) error {
 	// So the underlying serverEntriesBucket could change after the serverEntryIDs
 	// list is built.
 
+	startTime := time.Now()
+	var moveToFrontDuration, entriesDuration time.Duration
+
 	var serverEntryIDs [][]byte
 	movedToFront := 0
 
@@ -882,45 +889,19 @@ func (iterator *ServerEntryIterator) reset(isInitialRound bool) error {
 
 			affinityServerEntryID = bucket.get(datastoreAffinityServerEntryIDKey)
 			if affinityServerEntryID != nil {
-				serverEntryIDs = append(serverEntryIDs, append([]byte(nil), affinityServerEntryID...))
+				serverEntryIDs = append(
+					serverEntryIDs, append([]byte(nil), affinityServerEntryID...))
 				shuffleHead = 1
 			}
 		}
 
-		bucket = tx.bucket(datastoreServerEntriesBucket)
-		cursor := bucket.cursor()
-		for key := cursor.firstKey(); key != nil; key = cursor.nextKey() {
-			if affinityServerEntryID != nil {
-				if bytes.Equal(affinityServerEntryID, key) {
-					continue
-				}
-			}
-			serverEntryIDs = append(serverEntryIDs, append([]byte(nil), key...))
-		}
-		cursor.close()
-
-		// Provide the GetLastServerEntryCount implementation. This snapshot
-		// of the number of server entries in the datastore is used for
-		// metrics; a snapshot is recorded here to avoid the overhead of
-		// datastore scans or operations when the metric is logged.
-
-		datastoreLastServerEntryCount.Store(int64(len(serverEntryIDs)))
-
-		// Randomly shuffle the entire list of server IDs, excluding the
-		// server affinity candidate.
-
-		for i := len(serverEntryIDs) - 1; i > shuffleHead-1; i-- {
-			j := prng.Intn(i+1-shuffleHead) + shuffleHead
-			serverEntryIDs[i], serverEntryIDs[j] = serverEntryIDs[j], serverEntryIDs[i]
-		}
-
-		// In the first round, or with some probability, move _potential_ replay
-		// candidates to the front of the list (excepting the server affinity slot,
-		// if any). This move is post-shuffle so the order is still randomized. To
+		// In the first round, or with some probability, move _potential_
+		// replay candidates to the front of the list (excepting the server
+		// affinity slot, if any). The move to front order is randomized. To
 		// save the memory overhead of unmarshaling all dial parameters, this
-		// operation just moves any server with a dial parameter record to the
-		// front. Whether the dial parameter remains valid for replay -- TTL,
-		// tactics/config unchanged, etc. --- is checked later.
+		// operation just moves any server with a dial parameter record to
+		// the front. Whether the dial parameter remains valid for replay --
+		// TTL, tactics/config unchanged, etc. --- is checked later.
 		//
 		// TODO: move only up to parameters.ReplayCandidateCount to front?
 
@@ -929,7 +910,7 @@ func (iterator *ServerEntryIterator) reset(isInitialRound bool) error {
 		// of the list. See MakeDialParameters and doDSLFetch for more
 		// details about the DSLPendingPrioritizeDial scheme.
 		//
-		// Limitation: the move-to-front could be balanced beween
+		// Limitation: the move-to-front could be balanced between
 		// DSLPendingPrioritizeDial and regular replay cases, however that
 		// would require unmarshaling all dial parameters, which we are avoiding.
 
@@ -939,42 +920,134 @@ func (iterator *ServerEntryIterator) reset(isInitialRound bool) error {
 		maxMoveToFront := p.Int(parameters.ServerEntryIteratorMaxMoveToFront)
 		p.Close()
 
+		var movedToFrontLookup map[string]struct{}
+
 		if !iterator.isPruneServerEntryIterator &&
 			(isInitialRound || prng.FlipWeightedCoin(moveToFrontProbability)) &&
 			replayCandidateCount != 0 &&
 			maxMoveToFront != 0 {
 
+			moveToFrontStartTime := time.Now()
+
 			networkID := []byte(iterator.config.GetNetworkID())
 
+			serverEntriesBucket := tx.bucket(datastoreServerEntriesBucket)
 			dialParamsBucket := tx.bucket(datastoreDialParametersBucket)
-			i := shuffleHead
-			j := len(serverEntryIDs) - 1
-			for {
-				if maxMoveToFront >= 0 && movedToFront >= maxMoveToFront {
-					break
+			moveToFrontServerEntryIDs := make([][]byte, 0)
+
+			// Performance tradeoff: this implementation works best when
+			// datastoreDialParametersBucket is sparse and significantly
+			// smaller than datastoreServerEntriesBucket. It will iterate
+			// over all keys, which means it processes records for all
+			// network IDs, not just the target network ID. This is still
+			// expected to be less work than a previous approach of iterating
+			// over all datastoreServerEntriesBucket and checking for a
+			// datastoreDialParametersBucket entry for every server entry and
+			// network ID.
+
+			cursor := dialParamsBucket.cursor()
+			for key := cursor.firstKey(); key != nil; key = cursor.nextKey() {
+				if ctx.Err() != nil {
+					cursor.close()
+					return errors.Trace(ctx.Err())
 				}
-				for ; i < j; i++ {
-					key := makeDialParametersKey(serverEntryIDs[i], networkID)
-					if dialParamsBucket.get(key) == nil {
-						break
+
+				// Assumes key format in makeDialParametersKey.
+				if !bytes.HasSuffix(key, networkID) {
+					continue
+				}
+				serverEntryID := key[:len(key)-len(networkID)]
+				if len(serverEntryID) == 0 ||
+					serverEntriesBucket.get(serverEntryID) == nil {
+					continue
+				}
+
+				if affinityServerEntryID != nil &&
+					bytes.Equal(affinityServerEntryID, serverEntryID) {
+					continue
+				}
+
+				moveToFrontServerEntryIDs = append(
+					moveToFrontServerEntryIDs, append([]byte(nil), serverEntryID...))
+			}
+			cursor.close()
+
+			for i := len(moveToFrontServerEntryIDs) - 1; i > 0; i-- {
+				j := prng.Intn(i + 1)
+				moveToFrontServerEntryIDs[i], moveToFrontServerEntryIDs[j] =
+					moveToFrontServerEntryIDs[j], moveToFrontServerEntryIDs[i]
+			}
+
+			if maxMoveToFront >= 0 &&
+				len(moveToFrontServerEntryIDs) > maxMoveToFront {
+				moveToFrontServerEntryIDs =
+					moveToFrontServerEntryIDs[:maxMoveToFront]
+			}
+
+			movedToFront = len(moveToFrontServerEntryIDs)
+
+			if movedToFront > 0 {
+
+				movedToFrontLookup = make(map[string]struct{}, len(moveToFrontServerEntryIDs))
+				for _, serverEntryID := range moveToFrontServerEntryIDs {
+					movedToFrontLookup[string(serverEntryID)] = struct{}{}
+				}
+
+				serverEntryIDs = append(serverEntryIDs, moveToFrontServerEntryIDs...)
+
+				shuffleHead += len(moveToFrontServerEntryIDs)
+			}
+
+			moveToFrontDuration = time.Since(moveToFrontStartTime)
+		}
+
+		entriesStartTime := time.Now()
+
+		movedToFrontRemaining := movedToFront
+
+		bucket = tx.bucket(datastoreServerEntriesBucket)
+		cursor := bucket.cursor()
+		for key := cursor.firstKey(); key != nil; key = cursor.nextKey() {
+			if ctx.Err() != nil {
+				cursor.close()
+				return errors.Trace(ctx.Err())
+			}
+			if affinityServerEntryID != nil &&
+				bytes.Equal(affinityServerEntryID, key) {
+				continue
+			}
+			if movedToFrontLookup != nil {
+				// Avoid []byte-to-string allocations when there is no lookup,
+				// or after all the matches have been hit.
+				if _, ok := movedToFrontLookup[string(key)]; ok {
+					movedToFrontRemaining -= 1
+					if movedToFrontRemaining == 0 {
+						movedToFrontLookup = nil
 					}
-				}
-				for ; i < j; j-- {
-					key := makeDialParametersKey(serverEntryIDs[j], networkID)
-					if dialParamsBucket.get(key) != nil {
-						break
-					}
-				}
-				if i < j {
-					serverEntryIDs[i], serverEntryIDs[j] = serverEntryIDs[j], serverEntryIDs[i]
-					movedToFront += 1
-					i++
-					j--
-				} else {
-					break
+					continue
 				}
 			}
+			serverEntryIDs = append(serverEntryIDs, append([]byte(nil), key...))
 		}
+		cursor.close()
+
+		// Randomly shuffle the tail of the server ID list, excluding the
+		// server affinity candidate and any move-to-front candidates.
+
+		tailStart := shuffleHead
+		for i := len(serverEntryIDs) - 1; i > tailStart; i-- {
+			j := prng.Intn(i+1-tailStart) + tailStart
+			serverEntryIDs[i], serverEntryIDs[j] = serverEntryIDs[j], serverEntryIDs[i]
+		}
+
+		entriesDuration = time.Since(entriesStartTime)
+
+		// Provide the GetLastServerEntryCount implementation. This snapshot
+		// of the number of server entries in the datastore is used for
+		// metrics; a snapshot is recorded here to avoid the overhead of
+		// datastore scans or operations when the metric is logged.
+
+		datastoreLastServerEntryCount.Store(int64(len(serverEntryIDs)))
 
 		return nil
 	})
@@ -984,6 +1057,14 @@ func (iterator *ServerEntryIterator) reset(isInitialRound bool) error {
 
 	iterator.serverEntryIDs = serverEntryIDs
 	iterator.serverEntryIndex = 0
+
+	NoticeInfo(
+		"ServerEntryIterator.reset: entries %d, moved-to-front %d; durations: move-to-front %s, entries %s, total %s",
+		len(serverEntryIDs),
+		movedToFront,
+		moveToFrontDuration.String(),
+		entriesDuration.String(),
+		time.Since(startTime).String())
 
 	if iterator.updateMoveToFrontMetrics {
 
@@ -1004,7 +1085,7 @@ func (iterator *ServerEntryIterator) Close() {
 
 // Next returns the next server entry, by rank, for a ServerEntryIterator.
 // Returns nil with no error when there is no next item.
-func (iterator *ServerEntryIterator) Next() (*protocol.ServerEntry, error) {
+func (iterator *ServerEntryIterator) Next(ctx context.Context) (*protocol.ServerEntry, error) {
 
 	var serverEntry *protocol.ServerEntry
 	var err error
@@ -1037,6 +1118,9 @@ func (iterator *ServerEntryIterator) Next() (*protocol.ServerEntry, error) {
 	// Loop until we have the next server entry that matches the iterator
 	// filter requirements.
 	for {
+		if ctx.Err() != nil {
+			return nil, errors.Trace(ctx.Err())
+		}
 		if iterator.serverEntryIndex >= len(iterator.serverEntryIDs) {
 			// There is no next item
 			return nil, nil
@@ -2036,6 +2120,10 @@ func UpdateCheckServerEntryTagsEndTime(config *Config, checkCount int, pruneCoun
 // due.
 func GetCheckServerEntryTags(config *Config) ([]string, int, error) {
 
+	// TODO: pass in controller.runCtx. For now, PruneServerEntryIterator
+	// skips move-to-front work and the following loop is time bounded.
+	ctx := context.Background()
+
 	if disableCheckServerEntryTags.Load() {
 		return nil, 0, nil
 	}
@@ -2055,7 +2143,7 @@ func GetCheckServerEntryTags(config *Config) ([]string, int, error) {
 	minimumAgeForPruning := p.Duration(parameters.ServerEntryMinimumAgeForPruning)
 	p.Close()
 
-	iterator, err := NewPruneServerEntryIterator(config)
+	iterator, err := NewPruneServerEntryIterator(ctx, config)
 	if err != nil {
 		return nil, 0, errors.Trace(err)
 	}
@@ -2066,7 +2154,7 @@ func GetCheckServerEntryTags(config *Config) ([]string, int, error) {
 
 	for {
 
-		serverEntry, err := iterator.Next()
+		serverEntry, err := iterator.Next(ctx)
 		if err != nil {
 			return nil, 0, errors.Trace(err)
 		}

--- a/psiphon/dialParameters_test.go
+++ b/psiphon/dialParameters_test.go
@@ -61,6 +61,7 @@ func (t *testNetworkGetter) GetNetworkID() string {
 func runDialParametersAndReplay(t *testing.T, tunnelProtocol string) {
 
 	t.Logf("Test %s...", tunnelProtocol)
+	ctx := context.Background()
 
 	testDataDirName, err := ioutil.TempDir("", "psiphon-dial-parameters-test")
 	if err != nil {
@@ -1098,7 +1099,7 @@ func runDialParametersAndReplay(t *testing.T, tunnelProtocol string) {
 
 	for i := 0; i < 5; i++ {
 
-		hasAffinity, iterator, err := NewServerEntryIterator(clientConfig)
+		hasAffinity, iterator, err := NewServerEntryIterator(ctx, clientConfig)
 		if err != nil {
 			t.Fatalf("NewServerEntryIterator failed: %s", err)
 		}
@@ -1111,7 +1112,7 @@ func runDialParametersAndReplay(t *testing.T, tunnelProtocol string) {
 
 		for j := 0; j < 20; j++ {
 
-			serverEntry, err := iterator.Next()
+			serverEntry, err := iterator.Next(ctx)
 			if err != nil {
 				t.Fatalf("ServerEntryIterator.Next failed: %s", err)
 			}
@@ -1127,14 +1128,14 @@ func runDialParametersAndReplay(t *testing.T, tunnelProtocol string) {
 			}
 		}
 
-		iterator.Reset()
+		iterator.Reset(ctx)
 
 		// Test: subsequent shuffles should not move the replay/DSL-prioritize candidates candidates
 
 		allMoveToFront := true
 		for j := 0; j < 20; j++ {
 
-			serverEntry, err := iterator.Next()
+			serverEntry, err := iterator.Next(ctx)
 			if err != nil {
 				t.Fatalf("ServerEntryIterator.Next failed: %s", err)
 			}
@@ -1165,7 +1166,7 @@ func runDialParametersAndReplay(t *testing.T, tunnelProtocol string) {
 			t.Fatalf("SetParameters failed: %s", err)
 		}
 
-		hasAffinity, iterator, err = NewServerEntryIterator(clientConfig)
+		hasAffinity, iterator, err = NewServerEntryIterator(ctx, clientConfig)
 		if err != nil {
 			t.Fatalf("NewServerEntryIterator failed: %s", err)
 		}
@@ -1176,7 +1177,7 @@ func runDialParametersAndReplay(t *testing.T, tunnelProtocol string) {
 
 		for j := 0; j < 5; j++ {
 
-			serverEntry, err := iterator.Next()
+			serverEntry, err := iterator.Next(ctx)
 			if err != nil {
 				t.Fatalf("ServerEntryIterator.Next failed: %s", err)
 			}
@@ -1195,7 +1196,7 @@ func runDialParametersAndReplay(t *testing.T, tunnelProtocol string) {
 		allMoveToFront = true
 		for j := 5; j < 20; j++ {
 
-			serverEntry, err := iterator.Next()
+			serverEntry, err := iterator.Next(ctx)
 			if err != nil {
 				t.Fatalf("ServerEntryIterator.Next failed: %s", err)
 			}

--- a/psiphon/exchange_test.go
+++ b/psiphon/exchange_test.go
@@ -20,6 +20,7 @@
 package psiphon
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -221,13 +222,15 @@ func TestServerEntryExchange(t *testing.T) {
 	checkFirstServerEntry := func(
 		fields protocol.ServerEntryFields, tunnelProtocol string, isExchanged bool) {
 
-		_, iterator, err := NewServerEntryIterator(config)
+		ctx := context.Background()
+
+		_, iterator, err := NewServerEntryIterator(ctx, config)
 		if err != nil {
 			t.Fatalf("NewServerEntryIterator failed: %s", err)
 		}
 		defer iterator.Close()
 
-		serverEntry, err := iterator.Next()
+		serverEntry, err := iterator.Next(ctx)
 		if err != nil {
 			t.Fatalf("ServerEntryIterator.Next failed: %s", err)
 		}

--- a/psiphon/server/server_test.go
+++ b/psiphon/server/server_test.go
@@ -3920,18 +3920,19 @@ func checkExpectedDiscoveredServer(
 	discoveryServers []*psinet.DiscoveryServer) error {
 
 	discoveredServers := make(map[string]*protocol.ServerEntry)
+	ctx := context.Background()
 
 	// Otherwise NewServerEntryIterator only returns TargetServerEntry.
 	clientConfig.TargetServerEntry = ""
 
-	_, iterator, err := psiphon.NewServerEntryIterator(clientConfig)
+	_, iterator, err := psiphon.NewServerEntryIterator(ctx, clientConfig)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	defer iterator.Close()
 
 	for {
-		serverEntry, err := iterator.Next()
+		serverEntry, err := iterator.Next(ctx)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -5459,7 +5460,9 @@ func scanServerEntries(
 		testCase *pruneServerEntryTestCase,
 		serverEntry *protocol.ServerEntry)) {
 
-	_, iterator, err := psiphon.NewServerEntryIterator(clientConfig)
+	ctx := context.Background()
+
+	_, iterator, err := psiphon.NewServerEntryIterator(ctx, clientConfig)
 	if err != nil {
 		t.Fatalf("NewServerEntryIterator failed: %s", err)
 	}
@@ -5467,7 +5470,7 @@ func scanServerEntries(
 
 	for {
 
-		serverEntry, err := iterator.Next()
+		serverEntry, err := iterator.Next(ctx)
 		if err != nil {
 			t.Fatalf("ServerIterator.Next failed: %s", err)
 		}

--- a/psiphon/tactics.go
+++ b/psiphon/tactics.go
@@ -95,7 +95,7 @@ func GetTactics(ctx context.Context, config *Config, useStoredTactics bool) (fet
 			return
 		}
 
-		iterator, err := NewTacticsServerEntryIterator(config)
+		iterator, err := NewTacticsServerEntryIterator(ctx, config)
 		if err != nil {
 			NoticeWarning("tactics iterator failed: %s", errors.Trace(err))
 			return
@@ -111,7 +111,7 @@ func GetTactics(ctx context.Context, config *Config, useStoredTactics bool) (fet
 				return
 			}
 
-			serverEntry, err := iterator.Next()
+			serverEntry, err := iterator.Next(ctx)
 			if err != nil {
 				NoticeWarning("tactics iterator failed: %s", errors.Trace(err))
 				return
@@ -126,7 +126,7 @@ func GetTactics(ctx context.Context, config *Config, useStoredTactics bool) (fet
 					return
 				}
 
-				err := iterator.Reset()
+				err := iterator.Reset(ctx)
 				if err != nil {
 					NoticeWarning("tactics iterator failed: %s", errors.Trace(err))
 					return


### PR DESCRIPTION
- Add DisableServerEntriesReporter to optionally skip expensive server entry
  scan for reporting AvailableEgressRegions and CandidateServers.
- Optimize server entry iterator initialization algorithm.
- Log server entry iterator initialization timings.
- Ensure server entry iterator and constraint scan operations exit quickly on
  establishing stop/restart.