### PR TITLE
Add push payload entry metadata and size estimation

### DIFF
--- a/psiphon/common/push/push.go
+++ b/psiphon/common/push/push.go
@@ -227,9 +227,16 @@ type MakePushPayloadsResult struct {
 	// PayloadEntryCounts contains the number of entries in each payload, aligned
 	// by index with Payloads.
 	PayloadEntryCounts []int
+	// PayloadEntryIndexes contains original input indexes for each entry in each
+	// payload, aligned by index with Payloads.
+	PayloadEntryIndexes [][]int
+	// EntryEncodedSizes contains CBOR-encoded PrioritizedServerEntry sizes,
+	// aligned by index with the original input entries.
+	EntryEncodedSizes []int
 	// SkippedIndexes contains original input indexes for entries that could not
 	// fit into a payload when max payload size is enforced.
-	SkippedIndexes []int
+	SkippedIndexes     []int
+	expiresEncodedSize int
 }
 
 type payloadBuffers struct {
@@ -328,6 +335,51 @@ func (m *PushPayloadMaker) MakePushPayloads(
 	prioritizedServerEntries []*PrioritizedServerEntry,
 	maxPayloadSizeBytes int) (MakePushPayloadsResult, error) {
 
+	return m.makePushPayloads(
+		minPadding,
+		maxPadding,
+		TTL,
+		prioritizedServerEntries,
+		maxPayloadSizeBytes)
+}
+
+// EstimatePushPayloadSize estimates the final obfuscated payload size using
+// metadata from MakePushPayloads. entrySizeSum is the sum of the CBOR-encoded
+// PrioritizedServerEntry sizes for the payload, and paddingSize is the
+// requested SignedPayload padding length.
+func (m *PushPayloadMaker) EstimatePushPayloadSize(
+	result MakePushPayloadsResult,
+	numEntries int,
+	entrySizeSum int,
+	paddingSize int) (int, error) {
+
+	if result.expiresEncodedSize <= 0 {
+		return 0, errors.TraceNew("missing push payload metadata")
+	}
+	if numEntries < 0 {
+		return 0, errors.TraceNew("invalid entry count")
+	}
+	if entrySizeSum < 0 {
+		return 0, errors.TraceNew("invalid entry size sum")
+	}
+	if paddingSize < 0 || paddingSize > maxPaddingLimit {
+		return 0, errors.TraceNew("invalid padding size")
+	}
+
+	return m.computeObfuscatedPayloadSize(
+		result.expiresEncodedSize,
+		numEntries,
+		entrySizeSum,
+		paddingSize), nil
+}
+
+func (m *PushPayloadMaker) makePushPayloads(
+	minPadding int,
+	maxPadding int,
+	TTL time.Duration,
+	prioritizedServerEntries []*PrioritizedServerEntry,
+	maxPayloadSizeBytes int) (MakePushPayloadsResult, error) {
+
 	result := MakePushPayloadsResult{}
 
 	if len(prioritizedServerEntries) == 0 {
@@ -346,6 +398,23 @@ func (m *PushPayloadMaker) MakePushPayloads(
 
 	// maxPayloadSizeBytes <= 0 means no payload size cap is enforced.
 	if maxPayloadSizeBytes <= 0 {
+		expiresEncoded, err := protocol.CBOREncoding.Marshal(expires)
+		if err != nil {
+			return result, errors.Trace(err)
+		}
+		result.expiresEncodedSize = len(expiresEncoded)
+		result.EntryEncodedSizes = make([]int, len(prioritizedServerEntries))
+		entryIndexes := make([]int, len(prioritizedServerEntries))
+		for i, entry := range prioritizedServerEntries {
+			encodedEntry, err := protocol.CBOREncoding.Marshal(entry)
+			if err != nil {
+				return result, errors.Trace(err)
+			}
+			result.EntryEncodedSizes[i] = len(encodedEntry)
+			entryIndexes[i] = i
+		}
+		result.PayloadEntryIndexes = append(result.PayloadEntryIndexes, entryIndexes)
+
 		paddingSize := prng.Range(minPadding, maxPadding)
 		payload, err := m.buildObfuscatedPayload(
 			bufs, prioritizedServerEntries, expires, paddingSize)
@@ -364,8 +433,10 @@ func (m *PushPayloadMaker) MakePushPayloads(
 		return result, errors.Trace(err)
 	}
 	expiresEncodedSize := len(expiresEncoded)
+	result.expiresEncodedSize = expiresEncodedSize
 
 	// Compute encoded sizes for each PrioritizedServerEntry.
+	result.EntryEncodedSizes = make([]int, len(prioritizedServerEntries))
 	serverEntries := make(
 		[]sortablePrioritizedServerEntry, 0, len(prioritizedServerEntries))
 	for i, entry := range prioritizedServerEntries {
@@ -374,10 +445,13 @@ func (m *PushPayloadMaker) MakePushPayloads(
 			return result, errors.Trace(err)
 		}
 
+		encodedSize := len(encodedEntry)
+		result.EntryEncodedSizes[i] = encodedSize
+
 		serverEntries = append(serverEntries, sortablePrioritizedServerEntry{
 			entry:         entry,
 			originalIndex: i,
-			encodedSize:   len(encodedEntry),
+			encodedSize:   encodedSize,
 		})
 	}
 
@@ -393,6 +467,7 @@ func (m *PushPayloadMaker) MakePushPayloads(
 	// Worst-case each PrioritizedServerEntry gets its own bin.
 	type payloadBin struct {
 		serverEntries []*PrioritizedServerEntry
+		entryIndexes  []int
 		paddingSize   int
 		// sumServerEntrySize is the total encoded size of all server
 		// entries in this bin, used to compute the obfuscated payload size.
@@ -454,6 +529,7 @@ func (m *PushPayloadMaker) MakePushPayloads(
 			}
 			bi := candidates[best].binIndex
 			bins[bi].serverEntries = append(bins[bi].serverEntries, sortedServerEntry.entry)
+			bins[bi].entryIndexes = append(bins[bi].entryIndexes, sortedServerEntry.originalIndex)
 			bins[bi].sumServerEntrySize += sortedServerEntry.encodedSize
 			continue
 		}
@@ -470,11 +546,13 @@ func (m *PushPayloadMaker) MakePushPayloads(
 			continue
 		}
 
-		bins = append(bins, payloadBin{
+		bin := payloadBin{
 			serverEntries:      []*PrioritizedServerEntry{sortedServerEntry.entry},
+			entryIndexes:       []int{sortedServerEntry.originalIndex},
 			paddingSize:        paddingSize,
 			sumServerEntrySize: sortedServerEntry.encodedSize,
-		})
+		}
+		bins = append(bins, bin)
 	}
 
 	// Apply random padding to each bin, respecting maxPayloadSizeBytes.
@@ -502,6 +580,7 @@ func (m *PushPayloadMaker) MakePushPayloads(
 
 	result.Payloads = make([][]byte, 0, len(bins))
 	result.PayloadEntryCounts = make([]int, 0, len(bins))
+	result.PayloadEntryIndexes = make([][]int, 0, len(bins))
 
 	for _, bin := range bins {
 		payload, err := m.buildObfuscatedPayload(
@@ -517,6 +596,8 @@ func (m *PushPayloadMaker) MakePushPayloads(
 		result.Payloads = append(result.Payloads, payload)
 		result.PayloadEntryCounts = append(
 			result.PayloadEntryCounts, len(bin.serverEntries))
+		result.PayloadEntryIndexes = append(
+			result.PayloadEntryIndexes, bin.entryIndexes)
 	}
 
 	return result, nil

--- a/psiphon/common/push/push_test.go
+++ b/psiphon/common/push/push_test.go
@@ -456,6 +456,12 @@ func TestMakePushPayloads_MetadataIntegrity(t *testing.T) {
 	if len(result.Payloads) != len(result.PayloadEntryCounts) {
 		t.Fatalf("payload/entry-count mismatch: %d vs %d", len(result.Payloads), len(result.PayloadEntryCounts))
 	}
+	if len(result.Payloads) != len(result.PayloadEntryIndexes) {
+		t.Fatalf("payload/entry-index mismatch: %d vs %d", len(result.Payloads), len(result.PayloadEntryIndexes))
+	}
+	if len(result.EntryEncodedSizes) != len(entries) {
+		t.Fatalf("entry encoded size count: got %d want %d", len(result.EntryEncodedSizes), len(entries))
+	}
 
 	totalPayloadEntries := 0
 	for _, payloadEntryCount := range result.PayloadEntryCounts {
@@ -475,6 +481,157 @@ func TestMakePushPayloads_MetadataIntegrity(t *testing.T) {
 			t.Fatalf("duplicate skipped index: %d", skippedIndex)
 		}
 		seenSkippedIndexes[skippedIndex] = true
+	}
+}
+
+func TestMakePushPayloads_EntryMetadata(t *testing.T) {
+
+	obfuscationKey, publicKey, privateKey, err := GenerateKeys()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := makeTestPrioritizedServerEntries(18, func(i int) int {
+		return (i % 6) * 80
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	oversizeEntry, err := makeTestPrioritizedServerEntry(2000000, 300000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oversizeIndex := len(entries)
+	entries = append(entries, oversizeEntry)
+
+	maker, err := NewPushPayloadMaker(obfuscationKey, publicKey, privateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := maker.MakePushPayloads(
+		0, 0, 1*time.Hour, entries, 4096)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Payloads) != len(result.PayloadEntryCounts) {
+		t.Fatalf("payload/entry-count mismatch: %d vs %d", len(result.Payloads), len(result.PayloadEntryCounts))
+	}
+	if len(result.Payloads) != len(result.PayloadEntryIndexes) {
+		t.Fatalf("payload/entry-index mismatch: %d vs %d", len(result.Payloads), len(result.PayloadEntryIndexes))
+	}
+	if len(result.EntryEncodedSizes) != len(entries) {
+		t.Fatalf("entry encoded size count: got %d want %d", len(result.EntryEncodedSizes), len(entries))
+	}
+	for i, size := range result.EntryEncodedSizes {
+		if size <= 0 {
+			t.Fatalf("entry encoded size[%d]=%d, want positive", i, size)
+		}
+	}
+
+	if len(result.SkippedIndexes) != 1 || result.SkippedIndexes[0] != oversizeIndex {
+		t.Fatalf("unexpected skipped indexes: %v, want [%d]", result.SkippedIndexes, oversizeIndex)
+	}
+
+	seenIndexes := make(map[int]bool, len(entries))
+	for payloadIndex, payload := range result.Payloads {
+		entryIndexes := result.PayloadEntryIndexes[payloadIndex]
+		if len(entryIndexes) != result.PayloadEntryCounts[payloadIndex] {
+			t.Fatalf("payload %d entry indexes/count mismatch: %d vs %d",
+				payloadIndex, len(entryIndexes), result.PayloadEntryCounts[payloadIndex])
+		}
+
+		cursor := 0
+		imported, err := ImportPushPayload(
+			obfuscationKey,
+			publicKey,
+			payload,
+			func(
+				_ protocol.PackedServerEntryFields,
+				source string,
+				_ bool,
+				_ string,
+				_ string) error {
+
+				if cursor >= len(entryIndexes) {
+					return errors.TraceNew("payload imported more entries than metadata reported")
+				}
+				entryIndex := entryIndexes[cursor]
+				if entryIndex < 0 || entryIndex >= len(entries) {
+					return errors.Tracef("invalid payload entry index: %d", entryIndex)
+				}
+				if source != entries[entryIndex].Source {
+					return errors.Tracef("metadata source mismatch: got %q want %q", source, entries[entryIndex].Source)
+				}
+				if seenIndexes[entryIndex] {
+					return errors.Tracef("duplicate payload entry index: %d", entryIndex)
+				}
+				seenIndexes[entryIndex] = true
+				cursor += 1
+				return nil
+			},
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if imported != len(entryIndexes) || cursor != len(entryIndexes) {
+			t.Fatalf("payload %d import count/index mismatch: imported=%d cursor=%d indexes=%d",
+				payloadIndex, imported, cursor, len(entryIndexes))
+		}
+	}
+
+	if seenIndexes[oversizeIndex] {
+		t.Fatalf("oversize entry index %d appeared in payload metadata", oversizeIndex)
+	}
+	if len(seenIndexes)+len(result.SkippedIndexes) != len(entries) {
+		t.Fatalf("metadata does not account for all entries: seen=%d skipped=%d total=%d",
+			len(seenIndexes), len(result.SkippedIndexes), len(entries))
+	}
+}
+
+func TestMakePushPayloads_EntryMetadataNoMaxSize(t *testing.T) {
+
+	obfuscationKey, publicKey, privateKey, err := GenerateKeys()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := makeTestPrioritizedServerEntries(4, func(_ int) int {
+		return 0
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	maker, err := NewPushPayloadMaker(obfuscationKey, publicKey, privateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := maker.MakePushPayloads(
+		0, 0, 1*time.Hour, entries, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Payloads) != 1 {
+		t.Fatalf("payload count: got %d want 1", len(result.Payloads))
+	}
+	if len(result.PayloadEntryIndexes) != 1 {
+		t.Fatalf("payload entry index count: got %d want 1", len(result.PayloadEntryIndexes))
+	}
+	if len(result.EntryEncodedSizes) != len(entries) {
+		t.Fatalf("entry encoded size count: got %d want %d", len(result.EntryEncodedSizes), len(entries))
+	}
+	for i, entryIndex := range result.PayloadEntryIndexes[0] {
+		if entryIndex != i {
+			t.Fatalf("payload entry index[%d]=%d, want %d", i, entryIndex, i)
+		}
+		if result.EntryEncodedSizes[i] <= 0 {
+			t.Fatalf("entry encoded size[%d]=%d, want positive", i, result.EntryEncodedSizes[i])
+		}
 	}
 }
 
@@ -532,11 +689,24 @@ func TestComputeObfuscatedPayloadSize_MatchesMeasured(t *testing.T) {
 
 			computed := maker.computeObfuscatedPayloadSize(
 				expiresEncodedSize, numEntries, entrySizeSum, paddingSize)
+			estimated, err := maker.EstimatePushPayloadSize(
+				MakePushPayloadsResult{expiresEncodedSize: expiresEncodedSize},
+				numEntries,
+				entrySizeSum,
+				paddingSize)
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			if computed != measured {
 				t.Fatalf(
 					"mismatch: numEntries=%d paddingSize=%d computed=%d measured=%d",
 					numEntries, paddingSize, computed, measured)
+			}
+			if estimated != measured {
+				t.Fatalf(
+					"mismatch: numEntries=%d paddingSize=%d estimated=%d measured=%d",
+					numEntries, paddingSize, estimated, measured)
 			}
 		}
 	}


### PR DESCRIPTION
This helps callers to reason about packed payload membership.