### PR TITLE
Add sanity limits to logs and metric events produced from client inputs

### DIFF
--- a/psiphon/server/api.go
+++ b/psiphon/server/api.go
@@ -44,6 +44,9 @@ const (
 	MAX_API_PARAMS_SIZE = 256 * 1024 // 256KB
 	PADDING_MAX_BYTES   = 16 * 1024
 
+	PERSISTENT_STATS_MAX_LOGS_PER_TUNNEL         = 1024
+	PERSISTENT_STATS_MAX_DROPPED_LOGS_PER_TUNNEL = 16
+
 	CLIENT_PLATFORM_ANDROID = "Android"
 	CLIENT_PLATFORM_WINDOWS = "Windows"
 	CLIENT_PLATFORM_IOS     = "iOS"
@@ -138,7 +141,7 @@ func sshAPIRequestHandler(
 			support, protocol.PSIPHON_API_PROTOCOL_SSH, sshClient, params)
 		if err != nil {
 			// Handshake failed, disconnect the client.
-			sshClient.stop()
+			go sshClient.stop()
 			return nil, errors.Trace(err)
 		}
 		return responsePayload, nil
@@ -342,6 +345,7 @@ func handshakeAPIRequestHandler(
 			apiProtocol:             apiProtocol,
 			apiParams:               apiParams,
 			domainBytesChecksum:     domainBytesChecksum,
+			hasDomainBytesRegexes:   len(httpsRequestRegexes) > 0,
 			establishedTunnelsCount: establishedTunnelsCount,
 			splitTunnelLookup:       splitTunnelLookup,
 			deviceRegion:            deviceRegion,
@@ -735,12 +739,66 @@ func connectedAPIRequestHandler(
 		return nil, errors.Trace(err)
 	}
 
+	connectedRequestTime := time.Now().UTC()
+	connectedTime := connectedRequestTime.Truncate(time.Hour)
+	connectedTimestamp := connectedTime.Format(time.RFC3339)
+	connectedRequestDay := time.Date(
+		connectedRequestTime.Year(),
+		connectedRequestTime.Month(),
+		connectedRequestTime.Day(),
+		0, 0, 0, 0, time.UTC)
+
 	// Note: unlock before use is only safe as long as referenced sshClient data,
 	// such as slices in handshakeState, is read-only after initially set.
 
 	sshClient.Lock()
+
 	authorizedAccessTypes := sshClient.handshakeState.authorizedAccessTypes
+
+	lastConnectedRequestDay := time.Date(
+		sshClient.lastConnectedRequestTime.Year(),
+		sshClient.lastConnectedRequestTime.Month(),
+		sshClient.lastConnectedRequestTime.Day(),
+		0, 0, 0, 0, time.UTC)
+
+	acceptConnectedRequest :=
+		sshClient.lastConnectedRequestTime.IsZero() ||
+			connectedRequestDay.After(lastConnectedRequestDay)
+
+	logUnacceptedConnectedRequest := false
+
+	if acceptConnectedRequest {
+		sshClient.lastConnectedRequestTime = connectedRequestTime
+		sshClient.lastConnectedTimestamp = connectedTimestamp
+	} else {
+		connectedTimestamp = sshClient.lastConnectedTimestamp
+		if !sshClient.unacceptedConnectedRequestLogged {
+			sshClient.unacceptedConnectedRequestLogged = true
+			logUnacceptedConnectedRequest = true
+		}
+	}
+
 	sshClient.Unlock()
+
+	if logUnacceptedConnectedRequest {
+		log.WithTrace().Warning("connected request not accepted")
+	}
+
+	if !acceptConnectedRequest {
+		pad_response, _ := getPaddingSizeRequestParam(params, "pad_response")
+
+		connectedResponse := protocol.ConnectedResponse{
+			ConnectedTimestamp: connectedTimestamp,
+			Padding:            strings.Repeat(" ", pad_response),
+		}
+
+		responsePayload, err := json.Marshal(connectedResponse)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+
+		return responsePayload, nil
+	}
 
 	lastConnected, _ := getStringRequestParam(params, "last_connected")
 
@@ -751,8 +809,6 @@ func connectedAPIRequestHandler(
 	// here.
 
 	sshClient.updateAPIParameters(copyUpdateOnConnectedParams(params))
-
-	connectedTimestamp := common.TruncateTimestampToHour(common.GetCurrentTimestamp())
 
 	// The finest required granularity for unique users is daily. To save space,
 	// only record a "unique_user" log event when the client's last_connected is
@@ -767,11 +823,10 @@ func connectedAPIRequestHandler(
 		year, month, day := t1.Date()
 		d1 := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
 
-		t2, _ := time.Parse(time.RFC3339, connectedTimestamp)
-		year, month, day = t2.Date()
+		year, month, day = connectedTime.Date()
 		d2 := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
 
-		if t1.Before(t2) && d1 != d2 {
+		if t1.Before(connectedTime) && d1 != d2 {
 			logUniqueUser = true
 		}
 	}
@@ -878,8 +933,11 @@ func statusAPIRequestHandler(
 		return nil, errors.Trace(err)
 	}
 
+	// handleSSHRequests handles SSH requests serially, so there is no
+	// concurrent writer and these snapshots will not become stale.
 	sshClient.Lock()
 	authorizedAccessTypes := sshClient.handshakeState.authorizedAccessTypes
+	persistentStatsDroppedLogCount := sshClient.persistentStatsDroppedLogCount
 	sshClient.Unlock()
 
 	statusData, err := getJSONObjectRequestParam(params, "statusData")
@@ -893,6 +951,10 @@ func statusAPIRequestHandler(
 	// fail, and clients would then resend all the same stats again.
 
 	logQueue := make([]LogFields, 0)
+
+	loggedRemoteServerListStatDropped := false
+	loggedFailedTunnelStatDropped := false
+	droppedLogCount := 0
 
 	// Domain bytes transferred stats
 	// Older clients may not submit this data
@@ -949,7 +1011,18 @@ func statusAPIRequestHandler(
 			if err != nil {
 				// Occasionally, clients may send corrupt persistent stat data. Do not
 				// fail the status request, as this will lead to endless retries.
-				log.WithTraceFields(LogFields{"error": err}).Warning("remote_server_list_stats entry dropped")
+				if !loggedRemoteServerListStatDropped {
+					loggedRemoteServerListStatDropped = true
+					droppedLogCount++
+					total := persistentStatsDroppedLogCount + droppedLogCount
+					if total < PERSISTENT_STATS_MAX_DROPPED_LOGS_PER_TUNNEL {
+						log.WithTraceFields(LogFields{"error": err}).Warning(
+							"remote_server_list_stats entry dropped")
+					} else if total == PERSISTENT_STATS_MAX_DROPPED_LOGS_PER_TUNNEL {
+						log.WithTraceFields(LogFields{"error": err}).Warning(
+							"persistent stats dropped log limit exceeded")
+					}
+				}
 				continue
 			}
 
@@ -990,7 +1063,18 @@ func statusAPIRequestHandler(
 				//
 				// TODO: trigger pruning if the data corruption indicates corrupt server
 				// entry storage?
-				log.WithTraceFields(LogFields{"error": err}).Warning("failed_tunnel_stats entry dropped")
+				if !loggedFailedTunnelStatDropped {
+					loggedFailedTunnelStatDropped = true
+					droppedLogCount++
+					total := persistentStatsDroppedLogCount + droppedLogCount
+					if total < PERSISTENT_STATS_MAX_DROPPED_LOGS_PER_TUNNEL {
+						log.WithTraceFields(LogFields{"error": err}).Warning(
+							"failed_tunnel_stats entry dropped")
+					} else if total == PERSISTENT_STATS_MAX_DROPPED_LOGS_PER_TUNNEL {
+						log.WithTraceFields(LogFields{"error": err}).Warning(
+							"persistent stats dropped log limit exceeded")
+					}
+				}
 				continue
 			}
 
@@ -1083,6 +1167,38 @@ func statusAPIRequestHandler(
 		sshClient.checkedServerEntryTags += len(checkServerEntryTags)
 		sshClient.invalidServerEntryTags += invalidCount
 		sshClient.Unlock()
+	}
+
+	if droppedLogCount > 0 {
+		sshClient.Lock()
+		sshClient.persistentStatsDroppedLogCount += droppedLogCount
+		sshClient.Unlock()
+	}
+
+	if len(logQueue) > 0 {
+
+		sshClient.Lock()
+
+		logCount := len(logQueue)
+		remaining := PERSISTENT_STATS_MAX_LOGS_PER_TUNNEL -
+			sshClient.persistentStatsLogCount
+		if remaining < 0 {
+			remaining = 0
+		}
+		if logCount > remaining {
+			logCount = remaining
+		}
+		logLimitExceeded :=
+			logCount < len(logQueue) &&
+				sshClient.persistentStatsLogCount <= PERSISTENT_STATS_MAX_LOGS_PER_TUNNEL
+		sshClient.persistentStatsLogCount += len(logQueue)
+		logQueue = logQueue[:logCount]
+
+		sshClient.Unlock()
+
+		if logLimitExceeded {
+			log.WithTrace().Warning("persistent stats log limit exceeded")
+		}
 	}
 
 	for _, logItem := range logQueue {

--- a/psiphon/server/tunnelServer.go
+++ b/psiphon/server/tunnelServer.go
@@ -80,6 +80,8 @@ const (
 	ALERT_REQUEST_QUEUE_BUFFER_SIZE       = 16
 	SSH_MAX_CLIENT_COUNT                  = 500000
 	SSH_CLIENT_MAX_DSL_REQUEST_COUNT      = 128
+	SSH_CLIENT_MAX_REQUEST_FAIL_LOG_COUNT = 16
+	SSH_CLIENT_MAX_BLOCKLIST_HIT_LOGS     = 1024
 )
 
 // TunnelServer is the main server that accepts Psiphon client
@@ -1988,6 +1990,12 @@ type sshClient struct {
 	invalidServerEntryTags               int
 	sshProtocolBytesTracker              *sshProtocolBytesTracker
 	dslRequestCount                      int
+	lastConnectedRequestTime             time.Time
+	lastConnectedTimestamp               string
+	unacceptedConnectedRequestLogged     bool
+	persistentStatsLogCount              int
+	persistentStatsDroppedLogCount       int
+	blocklistHitsLogCount                int
 	proxyProtocolMetrics                 proxyProtocolMetrics
 }
 
@@ -2116,6 +2124,7 @@ type handshakeState struct {
 	authorizedAccessTypes     []string
 	authorizationsRevoked     bool
 	domainBytesChecksum       []byte
+	hasDomainBytesRegexes     bool
 	establishedTunnelsCount   int
 	splitTunnelLookup         *common.StringLookup
 	deviceRegion              string
@@ -3127,6 +3136,8 @@ func (sshClient *sshClient) runTunnel(
 
 func (sshClient *sshClient) handleSSHRequests(requests <-chan *ssh.Request) {
 
+	requestFailureCount := 0
+
 	for request := range requests {
 
 		// Requests are processed serially; API responses must be sent in request order.
@@ -3154,7 +3165,14 @@ func (sshClient *sshClient) handleSSHRequests(requests <-chan *ssh.Request) {
 		if err == nil {
 			err = request.Reply(true, responsePayload)
 		} else {
-			log.WithTraceFields(LogFields{"error": err}).Warning("request failed")
+			requestFailureCount++
+			if requestFailureCount < SSH_CLIENT_MAX_REQUEST_FAIL_LOG_COUNT {
+				log.WithTraceFields(LogFields{"error": err}).Warning(
+					"request failed")
+			} else if requestFailureCount == SSH_CLIENT_MAX_REQUEST_FAIL_LOG_COUNT {
+				log.WithTraceFields(LogFields{"error": err}).Warning(
+					"request failure log limit exceeded")
+			}
 			err = request.Reply(false, nil)
 		}
 		if err != nil {
@@ -3880,6 +3898,20 @@ func (sshClient *sshClient) logBlocklistHits(IP net.IP, domain string, tags []Bl
 
 	sshClient.Lock()
 
+	logCount := len(tags)
+	remaining := SSH_CLIENT_MAX_BLOCKLIST_HIT_LOGS -
+		sshClient.blocklistHitsLogCount
+	if remaining < 0 {
+		remaining = 0
+	}
+	if logCount > remaining {
+		logCount = remaining
+	}
+	logLimitExceeded :=
+		logCount < len(tags) &&
+			sshClient.blocklistHitsLogCount <= SSH_CLIENT_MAX_BLOCKLIST_HIT_LOGS
+	sshClient.blocklistHitsLogCount += len(tags)
+
 	// Log this using the client, not peer, GeoIP. In the case of in-proxy
 	// tunnel protocols, the client GeoIP fields will be None if the
 	// handshake does not complete. In that case, no port forwarding will
@@ -3898,7 +3930,11 @@ func (sshClient *sshClient) logBlocklistHits(IP net.IP, domain string, tags []Bl
 
 	sshClient.Unlock()
 
-	for _, tag := range tags {
+	if logLimitExceeded {
+		log.WithTrace().Warning("blocklist hits log limit exceeded")
+	}
+
+	for _, tag := range tags[:logCount] {
 		if IP != nil {
 			logFields["blocklist_ip_address"] = IP.String()
 		}
@@ -4436,6 +4472,12 @@ func (sshClient *sshClient) updateAPIParameters(
 func (sshClient *sshClient) acceptDomainBytes() bool {
 	sshClient.Lock()
 	defer sshClient.Unlock()
+
+	// Drop domain bytes when no regexes were configured for the client at
+	// handshake.
+	if !sshClient.handshakeState.hasDomainBytesRegexes {
+		return false
+	}
 
 	// When the domain bytes checksum differs from the checksum sent to the
 	// client in the handshake response, the psinet regex configuration has


### PR DESCRIPTION
- Prevent excess logs, but do not limit processing. For example, blocklist hit alerts are always sent.
- Limit connected request unique_user logging to once per tunnel per day.
- Cap number of remote_server_list/failed_tunnel/blocklist_hit metric logs per tunnel.
- Cap number of SSH API request error logs per tunnel.
- Ignore all host_bytes inputs when no domain bytes regex is configured.
- Fix potential hang in sshAPIRequestHandler due to sshClient.stop.