### PR TITLE
Fix tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,13 +47,6 @@ jobs:
           sudo apt-get install libnetfilter-queue-dev
           sudo apt-get install conntrack
 
-      - name: Install coverage tools
-        if: ${{ matrix.test-type == 'coverage' }}
-        run: |
-          go install github.com/modocache/gover@latest
-          go install github.com/mattn/goveralls@latest
-          go install golang.org/x/tools/cmd/cover@latest
-
       - name: Check environment
         run: |
           echo "GitHub workspace: $GITHUB_WORKSPACE"
@@ -109,9 +102,7 @@ jobs:
       # TODO: fix and re-enable test
       # sudo -E env "PATH=$PATH" go test -v -covermode=count -coverprofile=tun.coverprofile ./psiphon/common/tun
       - name: Run tests with coverage
-        env:
-          COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ matrix.test-type == 'coverage' && github.repository == 'Psiphon-Labs/psiphon-tunnel-core' }}
+        if: ${{ matrix.test-type == 'coverage' }}
         run: |
           cd ${{ github.workspace }}/go/src/github.com/Psiphon-Labs/psiphon-tunnel-core
           go test -v -covermode=count -coverprofile=common.coverprofile ./psiphon/common
@@ -144,8 +135,14 @@ jobs:
           go test -v -covermode=count -coverprofile=clientlib.coverprofile ./ClientLibrary/clientlib
           go test -v -covermode=count -coverprofile=analysis.coverprofile ./Server/logging/analysis
           go test -v -covermode=count -coverprofile=networkid.coverprofile ./psiphon/common/networkid
-          $GOPATH/bin/gover
-          $GOPATH/bin/goveralls -coverprofile=gover.coverprofile -service=github -repotoken "$COVERALLS_TOKEN"
+          awk 'FNR == 1 && /^mode:/ { if (seen++) next } { print }' *.coverprofile > gover.coverprofile
+          coverage="$(go tool cover -func=gover.coverprofile | tail -n 1 | awk '{print $3}')"
+          printf '%s\n' \
+            '+--------------------+' \
+            '|   Total Coverage   |' \
+            '+--------------------+'
+          printf '|       %-6s       |\n' "$coverage"
+          printf '%s\n' '+--------------------+'
 
       - name: Run server test with protobuf logging
         if: ${{ matrix.test-type == 'protobuf' }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI](https://github.com/Psiphon-Labs/psiphon-tunnel-core/actions/workflows/tests.yml/badge.svg)](https://github.com/Psiphon-Labs/psiphon-tunnel-core/actions/workflows/tests.yml) [![Coverage Status](https://coveralls.io/repos/github/Psiphon-Labs/psiphon-tunnel-core/badge.svg?branch=master)](https://coveralls.io/github/Psiphon-Labs/psiphon-tunnel-core?branch=master)
+[![CI](https://github.com/Psiphon-Labs/psiphon-tunnel-core/actions/workflows/tests.yml/badge.svg)](https://github.com/Psiphon-Labs/psiphon-tunnel-core/actions/workflows/tests.yml)
 
 
 Psiphon Tunnel Core README
@@ -166,4 +166,3 @@ Acknowledgements
 --------------------------------------------------------------------------------
 
 Psiphon Tunnel Core uses the following Go modules: https://github.com/Psiphon-Labs/psiphon-tunnel-core/blob/master/go.mod
-

--- a/psiphon/common/light/light_test.go
+++ b/psiphon/common/light/light_test.go
@@ -267,7 +267,7 @@ func runTestLightProxy(
 		expectedTLSClientHelloPadding = testTLSPaddingLength
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
 	serverGroup, serverCtx := errgroup.WithContext(ctx)
@@ -645,6 +645,9 @@ func runLightClient(
 	}
 	defer conn.Close()
 
+	interruptOnDone := context.AfterFunc(ctx, func() { _ = conn.Close() })
+	defer interruptOnDone()
+
 	innerTLSConn := tls.Client(conn, &tls.Config{
 		MinVersion:         tls.VersionTLS13,
 		InsecureSkipVerify: true,
@@ -657,8 +660,7 @@ func runLightClient(
 
 	payload := prng.Bytes(payloadSize)
 
-	readWriteGroup, readWriteCtx := errgroup.WithContext(ctx)
-
+	var readWriteGroup errgroup.Group
 	echoed := make([]byte, len(payload))
 	readWriteGroup.Go(func() error {
 		_, err := innerTLSConn.Write(payload)
@@ -666,12 +668,14 @@ func runLightClient(
 	})
 
 	readWriteGroup.Go(func() error {
-		_ = readWriteCtx
 		_, err := io.ReadFull(innerTLSConn, echoed)
 		return errors.Trace(err)
 	})
 
 	err = readWriteGroup.Wait()
+	if ctx.Err() != nil {
+		return errors.Trace(ctx.Err())
+	}
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/psiphon/common/quic/quic_test.go
+++ b/psiphon/common/quic/quic_test.go
@@ -324,6 +324,7 @@ func runQUIC(
 	expectedDanglingGoroutines := []string{
 		"quic-go.(*packetHandlerMap).Retire.func1",
 		"quic-go.(*packetHandlerMap).ReplaceWithClosed.func1",
+		"quic-go.(*packetHandlerMap).ReplaceWithClosed.func2",
 		"quic-go.(*packetHandlerMap).RetireResetToken.func1",
 		"gquic-go.(*packetHandlerMap).removeByConnectionIDAsString.func1",
 	}

--- a/psiphon/controller_test.go
+++ b/psiphon/controller_test.go
@@ -396,6 +396,7 @@ func TestAppResumed(t *testing.T) {
 	controllerRun(t,
 		&controllerRunConfig{
 			protocol:                 protocol.TUNNEL_PROTOCOL_SSH,
+			clientIsLatestVersion:    true,
 			disableUntunneledUpgrade: true,
 			doAppResumed:             true,
 		})
@@ -495,10 +496,9 @@ func controllerRun(t *testing.T, runConfig *controllerRunConfig) {
 	// TODO: vary this option
 	modifyConfig["CompressTactics"] = false
 
-	appResumedReconnectMilliseconds := 1
 	if runConfig.doAppResumed {
-		modifyConfig["SSHKeepAliveResumeReconnectInactivePeriodMilliseconds"] =
-			appResumedReconnectMilliseconds
+		// A zero inactivity threshold always triggers reconnect on app resume.
+		modifyConfig["SSHKeepAliveResumeReconnectInactivePeriodMilliseconds"] = 0
 	}
 
 	configJSON, _ = json.Marshal(modifyConfig)
@@ -778,10 +778,6 @@ func controllerRun(t *testing.T, runConfig *controllerRunConfig) {
 		if runConfig.doAppResumed {
 
 			// Test: AppResumed must trigger reestablishment
-
-			time.Sleep(
-				1*time.Second +
-					time.Duration(appResumedReconnectMilliseconds)*time.Millisecond)
 
 			controller.AppResumed()
 

--- a/psiphon/server/server_test.go
+++ b/psiphon/server/server_test.go
@@ -2536,10 +2536,10 @@ func runServer(t *testing.T, runConfig *runServerConfig) {
 	// The client still reports domain_bytes up when no port forwards are
 	// allowed (expectTrafficFailure).
 	//
-	// Limitation: this check is disabled in the in-proxy case since, in the
-	// self-proxy scheme, the proxy shuts down before the client can send its
-	// final status request.
-	expectDomainDestBytes := !runConfig.doChangeBytesConfig && !doInproxy
+	// In the in-proxy self-proxy scheme, the final status request races with
+	// proxy shutdown and domain bytes may or may not arrive.
+	allowDomainDestBytes := !runConfig.doChangeBytesConfig
+	requireDomainDestBytes := allowDomainDestBytes && !doInproxy
 
 	select {
 	case logFields := <-serverTunnelLog:
@@ -2621,7 +2621,7 @@ func runServer(t *testing.T, runConfig *runServerConfig) {
 		}
 	}
 
-	if expectDomainDestBytes {
+	if requireDomainDestBytes {
 		select {
 		case logFields := <-domainDestBytesLog:
 			err := checkExpectedDomainDestBytesLogFields(
@@ -2632,6 +2632,17 @@ func runServer(t *testing.T, runConfig *runServerConfig) {
 			}
 		default:
 			t.Fatalf("missing domain bytes log")
+		}
+	} else if allowDomainDestBytes {
+		select {
+		case logFields := <-domainDestBytesLog:
+			err := checkExpectedDomainDestBytesLogFields(
+				runConfig,
+				logFields)
+			if err != nil {
+				t.Fatalf("invalid domain dest bytes log fields: %s", err)
+			}
+		default:
 		}
 	} else {
 		select {


### PR DESCRIPTION
- Remove coveralls and all external dependencies for coverage tests.
- Fix expectDomainDestBytes/doInproxy case.
- Fix false positive dangling goroutine check.
- Fix AppResumed test.
- Allow more time for end-to-end light_test and interrupt runLightClient on timeout.