### PR TITLE
Adjust GetDSLAccessToken API

### DIFF
--- a/MobileLibrary/psi/psi.go
+++ b/MobileLibrary/psi/psi.go
@@ -26,7 +26,6 @@ package psi
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -492,6 +491,21 @@ func ImportPushPayload(payload []byte) bool {
 	return controller.ImportPushPayload(payload)
 }
 
+// GetDSLAccessToken returns the persisted opaque DSL access token as unpadded
+// Base64URL text. An empty string is returned when Psiphon is not running or
+// no token has been registered, or when retrieval fails. A
+// DSLAccessTokenAvailable notice indicates that a token is available.
+func GetDSLAccessToken() string {
+	controllerMutex.Lock()
+	defer controllerMutex.Unlock()
+
+	if controller == nil {
+		return ""
+	}
+
+	return controller.GetDSLAccessToken()
+}
+
 var sendFeedbackMutex sync.Mutex
 var sendFeedbackCtx context.Context
 var stopSendFeedback context.CancelFunc
@@ -657,31 +671,6 @@ func GetBuildInfo() string {
 		return ""
 	}
 	return string(buildInfo)
-}
-
-// GetDSLAccessToken returns the persisted opaque DSL access token as unpadded
-// Base64URL text. An empty string is returned when Psiphon is not running or no
-// token has been registered, or when retrieval fails; retrieval failures are
-// logged to diagnostics. A DSLAccessTokenAvailable notice indicates that a token
-// is available.
-func GetDSLAccessToken() string {
-	controllerMutex.Lock()
-	defer controllerMutex.Unlock()
-
-	if controller == nil {
-		return ""
-	}
-
-	token, err := controller.GetDSLAccessToken()
-	if err != nil {
-		psiphon.NoticeWarning("GetDSLAccessToken failed: %v", errors.Trace(err))
-		return ""
-	}
-	if len(token) == 0 {
-		return ""
-	}
-
-	return base64.RawURLEncoding.EncodeToString(token)
 }
 
 func GetPacketTunnelMTU() int {

--- a/psiphon/dsl.go
+++ b/psiphon/dsl.go
@@ -21,6 +21,7 @@ package psiphon
 
 import (
 	"context"
+	"encoding/base64"
 	"sync/atomic"
 	"time"
 
@@ -447,25 +448,36 @@ func isDSLAccessTokenRegistrationEnabled(config *Config) bool {
 	return enabled
 }
 
-// GetDSLAccessToken returns the persisted opaque DSL access token, as issued,
-// in its raw byte form. Nil is returned when registration is disabled or no
-// token is available. Callers exposing the token to a host application encode
-// it; see psi.GetDSLAccessToken.
-func (controller *Controller) GetDSLAccessToken() ([]byte, error) {
+// GetDSLAccessToken returns the persisted opaque DSL access token as unpadded
+// Base64URL text. An empty string is returned when no token has been
+// registered, or when retrieval fails; retrieval failures are logged to
+// diagnostics. A DSLAccessTokenAvailable notice indicates that a token is
+// available.
+func (controller *Controller) GetDSLAccessToken() string {
+
 	if !isDSLAccessTokenRegistrationEnabled(controller.config) {
-		return nil, nil
+		return ""
 	}
-	return getPersistedDSLAccessToken()
+
+	token, err := getPersistedDSLAccessToken()
+	if err != nil {
+		NoticeWarning("GetDSLAccessToken failed: %v", errors.Trace(err))
+		return ""
+	}
+
+	if len(token) == 0 {
+		return ""
+	}
+
+	return base64.RawURLEncoding.EncodeToString(token)
 }
 
 // announcePersistedDSLAccessToken emits a DSLAccessTokenAvailable notice when
 // a previously registered DSL access token is available to the host application.
 func (controller *Controller) announcePersistedDSLAccessToken() {
-	token, err := controller.GetDSLAccessToken()
-	if err != nil {
-		NoticeWarning("GetDSLAccessToken failed: %v", errors.Trace(err))
-		return
-	}
+
+	token := controller.GetDSLAccessToken()
+
 	if len(token) == 0 {
 		return
 	}

--- a/psiphon/dsl_test.go
+++ b/psiphon/dsl_test.go
@@ -79,11 +79,8 @@ func TestDSLAccessTokenRegistrationPersistence(t *testing.T) {
 	}
 
 	controller := &Controller{config: config}
-	got, err := controller.GetDSLAccessToken()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got, token) {
+	got := controller.GetDSLAccessToken()
+	if got != base64.RawURLEncoding.EncodeToString(token) {
 		t.Fatal("unexpected stored token")
 	}
 
@@ -108,11 +105,8 @@ func TestDSLAccessTokenRegistrationPersistence(t *testing.T) {
 	}
 	datastoreOpen = true
 
-	restartedToken, err := controller.GetDSLAccessToken()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(restartedToken, token) {
+	restartedToken := controller.GetDSLAccessToken()
+	if restartedToken != base64.RawURLEncoding.EncodeToString(token) {
 		t.Fatal("token was not persisted across restart")
 	}
 }
@@ -145,11 +139,8 @@ func TestDSLAccessTokenPolicyAndNotice(t *testing.T) {
 			if len(value.Data) != 0 {
 				t.Fatal("DSLAccessTokenAvailable notice contains data")
 			}
-			persistedToken, err := (&Controller{config: config}).GetDSLAccessToken()
-			if err != nil {
-				t.Fatal(err)
-			}
-			if !bytes.Equal(persistedToken, token) {
+			persistedToken := (&Controller{config: config}).GetDSLAccessToken()
+			if persistedToken != base64.RawURLEncoding.EncodeToString(token) {
 				t.Fatal("notice emitted before token persistence")
 			}
 			notices++
@@ -182,8 +173,8 @@ func TestDSLAccessTokenPolicyAndNotice(t *testing.T) {
 	}
 
 	config.EnableDSLAccessTokenRegistration = false
-	got, err := controller.GetDSLAccessToken()
-	if err != nil || len(got) != 0 {
+	got := controller.GetDSLAccessToken()
+	if got != "" {
 		t.Fatal("config-disabled access token was returned")
 	}
 	notices = 0
@@ -199,8 +190,8 @@ func TestDSLAccessTokenPolicyAndNotice(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	got, err = controller.GetDSLAccessToken()
-	if err != nil || len(got) != 0 {
+	got = controller.GetDSLAccessToken()
+	if got != "" {
 		t.Fatal("tactics-disabled access token was returned")
 	}
 	controller.announcePersistedDSLAccessToken()
@@ -290,11 +281,8 @@ func TestDSLAccessTokenRegistrationCorruptRecordSelfHeal(t *testing.T) {
 	// GetDSLAccessToken degrades to "no token", not an error (mobile binding
 	// path).
 	setCorruptRecord(corruptRecords[0])
-	token, err := (&Controller{config: config}).GetDSLAccessToken()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(token) != 0 {
+	token := (&Controller{config: config}).GetDSLAccessToken()
+	if token != "" {
 		t.Fatal("GetDSLAccessToken did not tolerate corrupt record")
 	}
 
@@ -304,11 +292,8 @@ func TestDSLAccessTokenRegistrationCorruptRecordSelfHeal(t *testing.T) {
 	if err := handleDSLAccessTokenRegistrationResponse([]byte("token")); err != nil {
 		t.Fatal(err)
 	}
-	token, err = (&Controller{config: config}).GetDSLAccessToken()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(token, []byte("token")) {
+	token = (&Controller{config: config}).GetDSLAccessToken()
+	if token != base64.RawURLEncoding.EncodeToString([]byte("token")) {
 		t.Fatal("registration did not overwrite corrupt record")
 	}
 }

--- a/psiphon/server/server_test.go
+++ b/psiphon/server/server_test.go
@@ -2270,12 +2270,9 @@ func runServer(t *testing.T, runConfig *runServerConfig) {
 		if runConfig.testDSLAccessToken {
 			waitOnNotification(t, dslAccessTokenAvailable, timeoutSignal, "DSL access token timeout exceeded")
 
-			token, err := controller.GetDSLAccessToken()
-			if err != nil {
-				t.Fatalf("GetDSLAccessToken failed: %v", err)
-			}
-			if !bytes.Equal(token, testDSLAccessToken) {
-				t.Fatalf("unexpected DSL access token: %x", token)
+			token := controller.GetDSLAccessToken()
+			if token != base64.RawURLEncoding.EncodeToString(testDSLAccessToken) {
+				t.Fatalf("unexpected DSL access token: %s", token)
 			}
 
 			requests := dslTestConfig.backend.GetDSLAccessTokenRegistrationRequests()


### PR DESCRIPTION
- Push the notice-or-error and base64 encoding down into the Controller layer so that behavior is consistent if Controller.GetDSLAccessToken is called directly.