### PR TITLE
Light proxy enhancements

### DIFF
--- a/psiphon/common/light/client.go
+++ b/psiphon/common/light/client.go
@@ -24,6 +24,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -36,7 +37,11 @@ import (
 )
 
 const (
-	clientInactivityTimeout = 5 * time.Minute
+	// Matches default parameters.LightProxyInactivityTimeout
+	clientInactivityTimeout = 2 * time.Minute
+
+	// NoInactivityTimeout disables the client read inactivity timeout.
+	NoInactivityTimeout time.Duration = -1
 )
 
 // TCPDialer is a callback that dials a TCP connection. The dialer allows for
@@ -267,12 +272,16 @@ func (client *Client) GetMetrics(resetCounters bool) *ClientMetrics {
 // The light proxy protocol requires the client to write first, and the light
 // header is prepended to the client's first write.
 //
+// inactivityTimeout specifies the read inactivity timeout. When zero, the
+// default timeout is applied. NoInactivityTimeout disables the timeout.
+//
 // The specified tlsProfile must be a utls TLS 1.3 ClientHello parrot
 // fingerprint, or a randomized fingerprint that produces a TLS 1.3
 // ClientHello with the given randomizedTLSProfileSeed.
 func (client *Client) Dial(
 	ctx context.Context,
 	additionalLogFields common.LogFields,
+	inactivityTimeout time.Duration,
 	networkType string,
 	tlsProfile string,
 	randomizedTLSProfileSeed *prng.Seed,
@@ -281,15 +290,19 @@ func (client *Client) Dial(
 	tlsPadding int,
 	destinationAddress string) (retConn *ClientConn, retErr error) {
 
+	switch {
+	case inactivityTimeout == NoInactivityTimeout:
+		// ActivityMonitoredConn uses zero to disable its timeout.
+		inactivityTimeout = 0
+	case inactivityTimeout < 0:
+		return nil, errors.TraceNew("invalid inactivity timeout")
+	case inactivityTimeout == 0:
+		inactivityTimeout = clientInactivityTimeout
+	}
+
 	// Start at 1 to distinguish from the zero value the proxy will record if
 	// the header is not delivered.
 	connectionNum := client.connectionNumber.Add(1)
-
-	passthroughMessage, err := obfuscator.MakeTLSPassthroughMessage(
-		true, client.obfuscationKey)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
 
 	logFields := common.LogFields{
 		"proxyID":           client.proxyID,
@@ -303,7 +316,10 @@ func (client *Client) Dial(
 	}
 	logFields.Add(additionalLogFields)
 
-	// Log once per connection. If the dial fails, log accumulated fields
+	client.config.Logger.WithTraceFields(
+		logFields).Info("light proxy connection start")
+
+	// Log the connection outcome. If the dial fails, log accumulated fields
 	// here. Otherwise, log on Close.
 	defer func() {
 		if retErr != nil {
@@ -321,9 +337,18 @@ func (client *Client) Dial(
 				logFields["error"] = retErr.Error()
 				client.config.Logger.WithTraceFields(
 					logFields).Warning("light proxy dial failed")
+			} else {
+				client.config.Logger.WithTraceFields(
+					logFields).Info("light proxy dial canceled")
 			}
 		}
 	}()
+
+	passthroughMessage, err := obfuscator.MakeTLSPassthroughMessage(
+		true, client.obfuscationKey)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 
 	start := time.Now()
 
@@ -390,9 +415,15 @@ func (client *Client) Dial(
 	logFields["isIPv6"] = isIPv6
 
 	// Wrapping here counts outer TLS handshake bytes.
+	//
+	// activeOnWrite is false: writes succeed locally, buffered by the OS,
+	// even when the peer is unreachable. A trickle of small writes on a dead
+	// connection could extend the deadline indefinitely.
 	bytesCounter := &bytesCounter{}
 	activityConn, err := common.NewActivityMonitoredConn(
-		tcpConn, clientInactivityTimeout, false, nil, bytesCounter)
+		tcpConn,
+		inactivityTimeout,
+		false, nil, bytesCounter)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -468,6 +499,27 @@ type ClientConn struct {
 	closeErr  error
 }
 
+func (conn *ClientConn) Read(b []byte) (int, error) {
+	n, err := conn.lightConn.Read(b)
+
+	// Preserve io.Reader EOF semantics. Other errors, including EOF wrapped
+	// after an incomplete frame, retain the client connection number.
+	if err != nil && err != io.EOF {
+		return n, errors.Tracef(
+			"connectionNum %d: %w", conn.connectionNum, err)
+	}
+	return n, err
+}
+
+func (conn *ClientConn) Write(b []byte) (int, error) {
+	n, err := conn.lightConn.Write(b)
+	if err != nil {
+		return n, errors.Tracef(
+			"connectionNum %d: %w", conn.connectionNum, err)
+	}
+	return n, nil
+}
+
 func (conn *ClientConn) Close() error {
 	conn.closeOnce.Do(func() {
 		conn.closeErr = errors.Trace(conn.lightConn.Close())
@@ -477,7 +529,7 @@ func (conn *ClientConn) Close() error {
 		conn.logFields["duration"] = conn.activityConn.GetActiveDuration().String()
 
 		conn.client.config.Logger.WithTraceFields(
-			conn.logFields).Info("light proxy connection")
+			conn.logFields).Info("light proxy connection end")
 	})
 	return conn.closeErr
 }

--- a/psiphon/common/light/light_test.go
+++ b/psiphon/common/light/light_test.go
@@ -137,21 +137,23 @@ func runTestLightProxyPassthrough() error {
 
 	receiver := newTestProxyEventReceiver(false, 0, false, "")
 
-	// Use a short inactivity timeout to check that passthrough relays are
-	// exempt from it.
-	inactivityTimeout := 1 * time.Second
+	// Use a short deadline and inactivity timeout value to check that
+	// passthrough relays are exempt from these timeouts.
+	timeout := 1 * time.Second
 
 	proxy, err := NewProxy(
 		&ProxyConfig{
-			Protocol:           LIGHT_PROTOCOL_TLS,
-			ListenAddresses:    []string{proxyAddress},
-			DialAddressIPv4:    proxyAddress,
-			ObfuscationKey:     prng.HexString(32),
-			TLSCertificate:     proxyCertPEM,
-			TLSPrivateKey:      proxyKeyPEM,
-			PassthroughAddress: webListener.Addr().String(),
-			AllowBogons:        true,
-			InactivityTimeout:  inactivityTimeout.String(),
+			Protocol:             LIGHT_PROTOCOL_TLS,
+			ListenAddresses:      []string{proxyAddress},
+			DialAddressIPv4:      proxyAddress,
+			ObfuscationKey:       prng.HexString(32),
+			TLSCertificate:       proxyCertPEM,
+			TLSPrivateKey:        proxyKeyPEM,
+			PassthroughAddress:   webListener.Addr().String(),
+			AllowBogons:          true,
+			PreHeaderDeadlineMin: timeout.String(),
+			PreHeaderDeadlineMax: timeout.String(),
+			InactivityTimeout:    timeout.String(),
 		},
 		func(string) common.GeoIPData { return common.GeoIPData{} },
 		receiver)
@@ -212,7 +214,7 @@ func runTestLightProxyPassthrough() error {
 		return errors.Trace(err)
 	}
 
-	time.Sleep(2 * inactivityTimeout)
+	time.Sleep(2 * timeout)
 
 	err = echo("passthrough echo 2")
 	if err != nil {
@@ -596,6 +598,7 @@ func runTestLightProxy(
 	_, err = clients[0].Dial(
 		ctx,
 		nil,
+		0,
 		testNetworkType,
 		testTLSProfile,
 		nil,
@@ -612,6 +615,7 @@ func runTestLightProxy(
 	conn, err := clients[0].Dial(
 		ctx,
 		nil,
+		0,
 		testNetworkType,
 		testTLSProfile,
 		nil,
@@ -653,6 +657,7 @@ func runLightClient(
 	conn, err := client.Dial(
 		ctx,
 		nil,
+		0,
 		networkType,
 		tlsProfile,
 		nil,

--- a/psiphon/common/light/lightproxy/main.go
+++ b/psiphon/common/light/lightproxy/main.go
@@ -506,7 +506,16 @@ func lightProxyTestFetch(
 		DisableKeepAlives: true,
 		DialContext: func(dialCtx context.Context, _, address string) (net.Conn, error) {
 			conn, err := lightClient.Dial(
-				dialCtx, nil, "UNKNOWN", protocol.TLS_PROFILE_CHROME_133, nil, "", false, 0, address)
+				dialCtx,
+				nil,
+				0,
+				"UNKNOWN",
+				protocol.TLS_PROFILE_CHROME_133,
+				nil,
+				"",
+				false,
+				0,
+				address)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}

--- a/psiphon/common/light/proxy.go
+++ b/psiphon/common/light/proxy.go
@@ -21,6 +21,7 @@ package light
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/hex"
 	std_errors "errors"
 	"net"
@@ -35,6 +36,7 @@ import (
 	"github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common"
 	"github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/errors"
 	"github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/obfuscator"
+	"github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/prng"
 	"github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/proxyheader"
 	"github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/tun"
 	lrucache "github.com/cognusion/go-cache-lru"
@@ -45,7 +47,10 @@ const (
 	LIGHT_PROTOCOL_TLS = "TLS"
 
 	obfuscationKeySize              = 32
-	defaultInactivityTimeout        = 60 * time.Second
+	defaultPreHeaderDeadlineMin     = 30 * time.Second
+	defaultPreHeaderDeadlineMax     = 120 * time.Second
+	preHeaderDeadlineStep           = 10 * time.Second
+	defaultInactivityTimeout        = 5 * time.Minute // Matches server.SSH_CONNECTION_READ_DEADLINE
 	defaultUpstreamDialTimeout      = 5 * time.Second
 	defaultRelayBufferSize          = 8192
 	rateLimiterReapHistoryFrequency = 300 * time.Second
@@ -80,6 +85,8 @@ type ProxyConfig struct {
 	TLSPrivateKey                                 []byte              `json:",omitempty"`
 	PassthroughAddress                            string              `json:",omitempty"`
 	AllowedDestinations                           []string            `json:",omitempty"`
+	PreHeaderDeadlineMin                          string              `json:",omitempty"`
+	PreHeaderDeadlineMax                          string              `json:",omitempty"`
 	InactivityTimeout                             string              `json:",omitempty"`
 	UpstreamDialTimeout                           string              `json:",omitempty"`
 	RelayBufferSize                               int                 `json:",omitempty"`
@@ -219,6 +226,7 @@ type Proxy struct {
 	obfuscatorSeedHistory      *obfuscator.SeedHistory
 	allowedDestinations        common.StringLookup
 	proxyProtocolHeaderConfigs map[string]proxyProtocolHeaderConfig
+	preHeaderDeadline          time.Duration
 	inactivityTimeout          time.Duration
 	upstreamDialTimeout        time.Duration
 	relayBufferSize            int
@@ -313,6 +321,39 @@ func NewProxy(
 		return nil, errors.Trace(err)
 	}
 
+	preHeaderDeadlineMin := defaultPreHeaderDeadlineMin
+	if config.PreHeaderDeadlineMin != "" {
+		var err error
+		preHeaderDeadlineMin, err = time.ParseDuration(config.PreHeaderDeadlineMin)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+
+	preHeaderDeadlineMax := defaultPreHeaderDeadlineMax
+	if config.PreHeaderDeadlineMax != "" {
+		var err error
+		preHeaderDeadlineMax, err = time.ParseDuration(config.PreHeaderDeadlineMax)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+
+	if preHeaderDeadlineMin < 0 || preHeaderDeadlineMax < preHeaderDeadlineMin {
+		return nil, errors.TraceNew("invalid pre-header deadline")
+	}
+
+	// Vary the pre-header deadline per proxy, using the selected value
+	// consistently.
+	seed := prng.Seed(sha256.Sum256([]byte(config.ObfuscationKey)))
+	deadlinePRNG, err := prng.NewPRNGWithSaltedSeed(&seed, "light-proxy-pre-header-deadline")
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	steps := int((preHeaderDeadlineMax - preHeaderDeadlineMin) / preHeaderDeadlineStep)
+	preHeaderDeadline := preHeaderDeadlineMin +
+		time.Duration(deadlinePRNG.Range(0, steps))*preHeaderDeadlineStep
+
 	inactivityTimeout := defaultInactivityTimeout
 	if config.InactivityTimeout != "" {
 		var err error
@@ -320,6 +361,10 @@ func NewProxy(
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
+	}
+
+	if inactivityTimeout < 0 {
+		return nil, errors.TraceNew("invalid inactivity timeout")
 	}
 
 	upstreamDialTimeout := defaultUpstreamDialTimeout
@@ -528,6 +573,7 @@ func NewProxy(
 		obfuscatorSeedHistory:      obfuscator.NewSeedHistory(nil),
 		allowedDestinations:        common.NewStringLookup(normalizedAllowedDestinations),
 		proxyProtocolHeaderConfigs: proxyProtocolHeaderConfigs,
+		preHeaderDeadline:          preHeaderDeadline,
 		inactivityTimeout:          inactivityTimeout,
 		upstreamDialTimeout:        upstreamDialTimeout,
 		relayBufferSize:            relayBufferSize,
@@ -887,14 +933,25 @@ func (proxy *Proxy) handleConn(ctx context.Context, conn net.Conn) (retErr error
 		}
 	}
 
+	// Pre-header there is a fixed deadline and no inactivity timeout.
+
 	activityConn, err := common.NewActivityMonitoredConn(
 		conn,
-		proxy.inactivityTimeout,
+		0,
 		false,
 		nil,
 		bytesCounter)
 	if err != nil {
 		return errors.Trace(err)
+	}
+
+	if proxy.preHeaderDeadline > 0 {
+		// Assumes ActivityMonitoredConn doesn't modify the deadline, which it
+		// doesn't with inactivityTimeout set to 0.
+		err := activityConn.SetDeadline(time.Now().Add(proxy.preHeaderDeadline))
+		if err != nil {
+			return errors.Trace(err)
+		}
 	}
 
 	// For TLS passthrough, the underlying client conn wrapped with tls.Server
@@ -938,9 +995,7 @@ func (proxy *Proxy) handleConn(ctx context.Context, conn net.Conn) (retErr error
 	tlsClientHelloPadding = connectionMetrics.ClientHelloPaddingLength
 	if err != nil {
 
-		// Disable the inactivity timeout to support the passthrough relay
-		// case. For genuine handshake failures this is inconsequential, as
-		// the conn is closed on return.
+		// Clear the pre-header deadline to support the passthrough relay case.
 		_ = activityConn.SetInactivityTimeout(0)
 
 		return errors.Trace(err)
@@ -971,6 +1026,12 @@ func (proxy *Proxy) handleConn(ctx context.Context, conn net.Conn) (retErr error
 	unassociateAfter()
 
 	completedLightHeader = time.Now().UTC()
+
+	// Replace the pre-header deadline with the inactivity timeout for an
+	// authentic client.
+	if err := activityConn.SetInactivityTimeout(proxy.inactivityTimeout); err != nil {
+		return errors.Trace(err)
+	}
 
 	// Apply limits after reading the header so that the ConnectionFailure
 	// will be accompanied by client characteristics such as sponsor ID. A

--- a/psiphon/common/parameters/parameters.go
+++ b/psiphon/common/parameters/parameters.go
@@ -595,6 +595,7 @@ const (
 	LightProxyCustomHostNameProbability                = "LightProxyCustomHostNameProbability"
 	LightProxyTunnelInactiveThreshold                  = "LightProxyTunnelInactiveThreshold"
 	LightProxyDialTimeout                              = "LightProxyDialTimeout"
+	LightProxyInactivityTimeout                        = "LightProxyInactivityTimeout"
 	LightProxyLimitDestinationAddresses                = "LightProxyLimitDestinationAddresses"
 	LightProxyPersonalPairingConnectionWorkerPoolSize  = "LightProxyPersonalPairingConnectionWorkerPoolSize"
 	HomepageURLQueryParameterClientFeatures            = "HomepageURLQueryParameterClientFeatures"
@@ -1283,6 +1284,7 @@ var defaultParameters = map[string]struct {
 	LightProxyUseRecommendedSNIProbability:            {value: 0.5, minimum: 0.0},
 	LightProxyTunnelInactiveThreshold:                 {value: 30 * time.Second, minimum: 0 * time.Millisecond},
 	LightProxyDialTimeout:                             {value: 20 * time.Second, minimum: 1 * time.Second, flags: useNetworkLatencyMultiplier},
+	LightProxyInactivityTimeout:                       {value: 2 * time.Minute, minimum: 1 * time.Second},
 	LightProxyLimitDestinationAddresses:               {value: []string{}},
 	LightProxyPersonalPairingConnectionWorkerPoolSize: {value: 2, minimum: 1},
 

--- a/psiphon/config.go
+++ b/psiphon/config.go
@@ -1361,6 +1361,7 @@ type Config struct {
 	LightProxyCustomHostNameProbability           *float64 `json:",omitempty"`
 	LightProxyTunnelInactiveThresholdMilliseconds *int     `json:",omitempty"`
 	LightProxyDialTimeoutMilliseconds             *int     `json:",omitempty"`
+	LightProxyInactivityTimeoutMilliseconds       *int     `json:",omitempty"`
 
 	TacticsWaitPeriodMilliseconds  *int     `json:",omitempty"`
 	TacticsRetryPeriodMilliseconds *int     `json:",omitempty"`
@@ -1406,7 +1407,7 @@ type Config struct {
 
 	serverEntryIterationMetricsUpdater atomic.Value
 
-	lightProxyClient                    atomic.Value
+	lightProxyClient                    atomic.Pointer[light.Client]
 	lightProxyDialParams                atomic.Value
 	lightProxyTunnelInactiveThreshold   atomic.Int64
 	lightProxyDialTimeout               atomic.Int64
@@ -2512,9 +2513,17 @@ func (config *Config) SetLightProxy(
 	config.lightProxyLimitDestinationAddresses.Store(limitDestinationAddresses)
 }
 
+func (config *Config) ClearLightProxy() {
+	config.lightProxyClient.Store(nil)
+	config.lightProxyDialParams.Store(&lightDialParameters{})
+	config.lightProxyTunnelInactiveThreshold.Store(0)
+	config.lightProxyDialTimeout.Store(0)
+	limitDestinationAddresses := common.NewStringLookup(nil)
+	config.lightProxyLimitDestinationAddresses.Store(&limitDestinationAddresses)
+}
+
 func (config *Config) GetLightProxyClient() *light.Client {
-	client, _ := config.lightProxyClient.Load().(*light.Client)
-	return client
+	return config.lightProxyClient.Load()
 }
 
 func (config *Config) GetLightProxyDialParameters() *lightDialParameters {
@@ -3686,6 +3695,10 @@ func (config *Config) makeConfigParameters() map[string]interface{} {
 
 	if config.LightProxyDialTimeoutMilliseconds != nil {
 		applyParameters[parameters.LightProxyDialTimeout] = fmt.Sprintf("%dms", *config.LightProxyDialTimeoutMilliseconds)
+	}
+
+	if config.LightProxyInactivityTimeoutMilliseconds != nil {
+		applyParameters[parameters.LightProxyInactivityTimeout] = fmt.Sprintf("%dms", *config.LightProxyInactivityTimeoutMilliseconds)
 	}
 
 	if config.LightProxyPersonalPairingConnectionWorkerPoolSize != 0 {

--- a/psiphon/controller.go
+++ b/psiphon/controller.go
@@ -26,6 +26,7 @@ package psiphon
 import (
 	"context"
 	"encoding/json"
+	std_errors "errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -121,7 +122,7 @@ type Controller struct {
 
 	currentNetworkMutex      sync.Mutex
 	currentNetworkCtx        context.Context
-	currentNetworkCancelFunc context.CancelFunc
+	currentNetworkCancelFunc context.CancelCauseFunc
 
 	signalLightProxyTestFetch chan struct{}
 }
@@ -214,7 +215,7 @@ func NewController(config *Config) (controller *Controller, err error) {
 	// interface changes.
 
 	controller.currentNetworkCtx, controller.currentNetworkCancelFunc =
-		context.WithCancel(context.Background())
+		context.WithCancelCause(context.Background())
 
 	// Initialize untunneledDialConfig, used by untunneled dials including
 	// remote server list and upgrade downloads.
@@ -263,6 +264,10 @@ func NewController(config *Config) (controller *Controller, err error) {
 		controller.packetTunnelClient = packetTunnelClient
 		controller.packetTunnelTransport = packetTunnelTransport
 	}
+
+	// As a failsafe, clear any light proxy state stored by a previous
+	// Controller sharing this Config.
+	config.ClearLightProxy()
 
 	if config.EnableLightProxyFallback {
 
@@ -575,7 +580,7 @@ func (controller *Controller) Run(ctx context.Context) {
 	}
 
 	// Cleanup current network context
-	controller.currentNetworkCancelFunc()
+	controller.currentNetworkCancelFunc(nil)
 
 	// All workers -- runTunnels, establishment workers, and auxilliary
 	// workers such as fetch remote server list and untunneled uprade
@@ -648,10 +653,10 @@ func (controller *Controller) NetworkChanged() {
 	controller.currentNetworkMutex.Lock()
 	defer controller.currentNetworkMutex.Unlock()
 
-	controller.currentNetworkCancelFunc()
+	controller.currentNetworkCancelFunc(std_errors.New("network changed"))
 
 	controller.currentNetworkCtx, controller.currentNetworkCancelFunc =
-		context.WithCancel(context.Background())
+		context.WithCancelCause(context.Background())
 }
 
 func (controller *Controller) getCurrentNetworkContext() context.Context {

--- a/psiphon/light.go
+++ b/psiphon/light.go
@@ -206,7 +206,18 @@ func dialLightProxy(
 	ctx context.Context,
 	config *Config,
 	lightClient *light.Client,
+	currentNetworkCtx context.Context,
+	inactivityTimeout time.Duration,
 	remoteAddr string) (net.Conn, error) {
+
+	// Interrupt the dial if the host's current active network changes.
+	// Merging the contexts also ensures ctx.Err() reflects a network change.
+	if currentNetworkCtx != nil {
+		var cancel context.CancelFunc
+		ctx, cancel = common.MergeContextCancel(
+			ctx, currentNetworkCtx)
+		defer cancel()
+	}
 
 	dialParams := config.GetLightProxyDialParameters()
 
@@ -225,6 +236,7 @@ func dialLightProxy(
 	conn, err := lightClient.Dial(
 		ctx,
 		logFields,
+		inactivityTimeout,
 		GetNetworkType(config.GetNetworkID()),
 		dialParams.TLSProfile,
 		dialParams.RandomizedTLSProfileSeed,
@@ -233,8 +245,14 @@ func dialLightProxy(
 		dialParams.TLSPadding,
 		remoteAddr)
 	if err != nil {
-		if ctx.Err() == nil {
+		// Retain replay parameters when the dial was canceled, including by a
+		// network change. Clear on dial timeout or other failures.
+		if ctx.Err() != context.Canceled {
 			config.SetLightProxyDialParameters(&lightDialParameters{})
+		}
+		// Annotate the error with the interrupt cause such as "network changed".
+		if ctx.Err() != nil {
+			err = errors.TraceMsg(err, context.Cause(ctx).Error())
 		}
 		return nil, errors.Trace(err)
 	}
@@ -310,6 +328,10 @@ func dialLightProxyRace(
 
 	dialTimeout := controller.config.GetLightProxyDialTimeout()
 
+	// Associate the dial and established connection with the current network.
+	// On NetworkChanged, both dials and connections are interrupted.
+	currentNetworkCtx := controller.getCurrentNetworkContext()
+
 	lightDialCtx, cancel := context.WithTimeout(
 		controller.runCtx, dialTimeout)
 	defer cancel()
@@ -321,8 +343,14 @@ func dialLightProxyRace(
 	go func() {
 		defer lightDialWaitGroup.Done()
 
+		p := controller.config.GetParameters().Get()
+		inactivityTimeout := p.Duration(
+			parameters.LightProxyInactivityTimeout)
+		p.Close()
+
 		conn, err := dialLightProxy(
-			lightDialCtx, controller.config, lightClient, remoteAddr)
+			lightDialCtx, controller.config, lightClient,
+			currentNetworkCtx, inactivityTimeout, remoteAddr)
 		lightResult <- lightProxyDialResult{conn: conn, err: err}
 	}()
 	defer lightDialWaitGroup.Wait()
@@ -347,11 +375,20 @@ func dialLightProxyRace(
 
 			if result.err == nil {
 				// Close downstreamConn when the light conn is closed. See
-				// Controller.Dial and TunneledConn.
-				return &lightProxyConn{
-					Conn:           result.conn,
-					downstreamConn: downstreamConn,
-				}, nil, nil
+				// Controller.Dial and TunneledConn. A network change also
+				// closes the conn, including downstreamConn.
+				conn := newLightProxyConn(
+					result.conn, downstreamConn, currentNetworkCtx)
+
+				// Avoid returning a conn for a network that changed while
+				// dialing.
+				if currentNetworkCtx.Err() != nil {
+					_ = conn.Close()
+					return nil, nil, errors.Trace(
+						context.Cause(currentNetworkCtx))
+				}
+
+				return conn, nil, nil
 			}
 
 			return nil, nil, errors.Trace(result.err)
@@ -372,10 +409,45 @@ func dialLightProxyRace(
 
 type lightProxyConn struct {
 	net.Conn
-	downstreamConn net.Conn
+	downstreamConn   net.Conn
+	unassociateAfter func() bool
+}
+
+func newLightProxyConn(
+	conn net.Conn,
+	downstreamConn net.Conn,
+	currentNetworkCtx context.Context) *lightProxyConn {
+
+	lightConn := &lightProxyConn{
+		Conn:           conn,
+		downstreamConn: downstreamConn,
+	}
+
+	// Close the conns when the network changes. This callback closes the
+	// conns directly rather than calling lightProxyConn.Close, which avoids
+	// a race with unassociateAfter assignment.
+	if currentNetworkCtx != nil {
+		lightConn.unassociateAfter = context.AfterFunc(
+			currentNetworkCtx,
+			func() {
+				if downstreamConn != nil {
+					_ = downstreamConn.Close()
+				}
+				_ = conn.Close()
+			})
+	}
+
+	return lightConn
 }
 
 func (conn *lightProxyConn) Close() error {
+
+	// The AfterFunc callback may run concurrently with Close; the
+	// underlying conns support multiple and concurrent Close calls.
+	if conn.unassociateAfter != nil {
+		conn.unassociateAfter()
+	}
+
 	if conn.downstreamConn != nil {
 		_ = conn.downstreamConn.Close()
 	}
@@ -397,7 +469,21 @@ func makeLightProxyTunnelTCPDialer(
 			return nil, errors.TraceNew("missing light proxy client")
 		}
 
-		conn, err := dialLightProxy(ctx, config, lightProxyClient, addr)
+		// The overall tunnel dial and subsequent tunnel operation take
+		// ownership of idle timeouts; set no light client inactivity
+		// timeout, which would otherwise conflict with SSH keepalive
+		// periods.
+		//
+		// No currentNetworkCtx is passed in; network changes are handled by
+		// existing tunnel operations, including SSH keepalive failures and
+		// tunnel re-establishment triggered by NetworkChanged.
+		//
+		// Limitation: an in-flight tunnel-mode light proxy dial is not
+		// promptly interrupted on network change; it runs to failure or is
+		// bounded by the tunnel establishment context.
+		conn, err := dialLightProxy(
+			ctx, config, lightProxyClient,
+			nil, light.NoInactivityTimeout, addr)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/psiphon/net.go
+++ b/psiphon/net.go
@@ -313,6 +313,10 @@ func (d *RefractionNetworkingDialer) DialContext(
 // LocalProxyRelay must close localConn in order to interrupt blocking
 // I/O calls when the upstream port forward is closed. remoteConn is
 // also closed before returning.
+//
+// Limitation: if one copy is blocked writing localConn while the other is
+// blocked reading it, closing only the remote transport may not promptly stop
+// the relay.
 func LocalProxyRelay(config *Config, proxyType string, localConn, remoteConn net.Conn) {
 
 	closing := int32(0)


### PR DESCRIPTION
- Reduce default client inactivity timeout with tactics/config overrides
- In light tunnel mode, let tunnel handle inactivity timeouts
- For diagnostic tracing, add "start" and "canceled" logs and add connectionNum to I/O errors
- Close in-flight dials and established connections on NetworkChanged